### PR TITLE
Feature/keyword search snippets

### DIFF
--- a/ppa/archive/solr.py
+++ b/ppa/archive/solr.py
@@ -1,5 +1,7 @@
+import json
 import logging
 
+from cached_property import cached_property
 from django.conf import settings
 import requests
 from SolrClient import SolrClient
@@ -159,7 +161,7 @@ class PagedSolrQuery(object):
         '''
         Return results of the Solr query.
 
-        :returns: docs as a list of dictionaries. 
+        :return: docs as a list of dictionaries.
         '''
         self._result = self.solr.query(self.solr_collection, self.query_opts)
         return self._result.docs
@@ -179,6 +181,20 @@ class PagedSolrQuery(object):
         if self._result is None:
             self.get_results()
         return self._result.get_json()
+
+    @cached_property
+    def raw_response(self):
+        '''Return the raw Solr result to provide access to return sections
+        not exposed by SolrClient'''
+        return json.loads(self.get_json())
+
+    def get_expanded(self):
+        '''get the expanded results from a collapsed query'''
+        return self.raw_response.get('expanded', {})
+
+    def get_highlighting(self):
+        '''get highlighting results from the response'''
+        return self.raw_response.get('highlighting', {})
 
     def set_limits(self, start, stop):
         '''Return a subsection of the results, to support slicing.'''

--- a/ppa/archive/templates/archive/list_digitizedworks.html
+++ b/ppa/archive/templates/archive/list_digitizedworks.html
@@ -28,23 +28,29 @@
         <p>{{ item.publisher }} {{ item.pub_place }} {{ item.pub_date }}</p>
         <p><small><a href="{{ item.src_url }}">{{ item.srcid }}</a></small></p>
         {% with results=page_groups|dict_item:item.id %}
-                <p>{{ results.numFound|intcomma }} page{{ results.numFound|pluralize }};
-                pages
+            {% if page_highlights %}
                 {% for page in results.docs %}
-                    {{ page.order }} {% if sort == 'relevance' %}<small> relevance: {{ page.score }}</small>{% endif %};
-                    {# coerce order to integer then format as number to drop leading zeroes #}
-                    {% if page_highlights %}
-                    <img src="https://babel.hathitrust.org/cgi/imgsrv/image?id={{ item.id }};seq={{ page.order|add:0|stringformat:'d' }};width=180"/>
+                    <div style="float: left; max-width: 50%">
+                        {# thumbnail image from hathi #}
+                        {# coerce page order to integer, then format as number to drop leading zeroes #}
+                        <img src="https://babel.hathitrust.org/cgi/imgsrv/image?id={{ item.id }};seq={{ page.order|add:0|stringformat:'d' }};width=180"
+                            style="float:left"/>
 
-                    {% with page_highlights=page_highlights|dict_item:page.id %}
-                        {% for snippet in page_highlights.content %}
-                        <p style="white-space: pre-wrap">{{ snippet|safe }}</p>
-                        <hr/>
-                        {% endfor %}
-                    {% endwith %}
-                    {% endif %}
+                        {% with page_highlights=page_highlights|dict_item:page.id %}
+                            {% for snippet in page_highlights.content %}
+                            <p style="white-space: pre-wrap">{{ snippet|safe }}</p>
+                            {% endfor %}
+                        {% endwith %}
+                    </div>
+
                 {% endfor %}
-                </p>
+
+                <div style="clear: both"/>
+                {# link to page with search if there are more than two pages #}
+                {% if results.numFound > 2 %}
+                <a href="{% url 'archive:detail' item.srcid %}?query={{ query }}">View all {{ results.numFound|intcomma }} page{{ results.numFound|pluralize }} →</a>
+                {% endif %}
+            {% endif %}
         {% endwith %}
         {% if item.collections %}
         <p><b>collections:</b> {{ item.collections|join:", " }}</p>

--- a/ppa/archive/templates/archive/list_digitizedworks.html
+++ b/ppa/archive/templates/archive/list_digitizedworks.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load humanize %}
+{% load humanize ppa_tags %}
 {% block page-subtitle %}Archive | {% endblock %}
 
 {% block content %}
@@ -23,21 +23,29 @@
     <li>
         <h3><a href="{% url 'archive:detail' item.srcid %}">{{ item.title }}</a></h3>
         <p>sort title: {{ item.title_exact }}</p>
-        <p>{{ item.author }}</p>
+        <p>author: {{ item.author }}</p>
         {% if item.enumcron %}<p>{{ item.enumcron }}</p> {% endif %}
         <p>{{ item.publisher }} {{ item.pub_place }} {{ item.pub_date }}</p>
         <p><small><a href="{{ item.src_url }}">{{ item.srcid }}</a></small></p>
-        {% for id, results in page_groups.items %}
-            {% if id == item.id %}
+        {% with results=page_groups|dict_item:item.id %}
                 <p>{{ results.numFound|intcomma }} page{{ results.numFound|pluralize }};
-                {# {{ results }} #}
                 pages
                 {% for page in results.docs %}
                     {{ page.order }} {% if sort == 'relevance' %}<small> relevance: {{ page.score }}</small>{% endif %};
+                    {# coerce order to integer then format as number to drop leading zeroes #}
+                    {% if page_highlights %}
+                    <img src="https://babel.hathitrust.org/cgi/imgsrv/image?id={{ item.id }};seq={{ page.order|add:0|stringformat:'d' }};width=180"/>
+
+                    {% with page_highlights=page_highlights|dict_item:page.id %}
+                        {% for snippet in page_highlights.content %}
+                        <p style="white-space: pre-wrap">{{ snippet|safe }}</p>
+                        <hr/>
+                        {% endfor %}
+                    {% endwith %}
+                    {% endif %}
                 {% endfor %}
                 </p>
-            {% endif %}
-        {% endfor %}
+        {% endwith %}
         {% if item.collections %}
         <p><b>collections:</b> {{ item.collections|join:", " }}</p>
         {% endif %}

--- a/ppa/archive/templatetags/ppa_tags.py
+++ b/ppa/archive/templatetags/ppa_tags.py
@@ -1,0 +1,10 @@
+from django.template.defaulttags import register
+
+@register.filter
+def dict_item(dictionary, key):
+    ''''Template filter to allow accessing dictionary value by variable key.
+    Example use::
+
+        {{ mydict|dict_item:keyvar }}
+    '''
+    return dictionary.get(key, None)

--- a/ppa/archive/tests/test_templatetags.py
+++ b/ppa/archive/tests/test_templatetags.py
@@ -1,0 +1,12 @@
+from ppa.archive.templatetags.ppa_tags import dict_item
+
+
+def test_dict_item():
+    # no error on not found
+    assert dict_item({}, 'foo') is None
+    # string key
+    assert dict_item({'foo': 'bar'}, 'foo') is 'bar'
+    # integer key
+    assert dict_item({13: 'lucky'}, 13) is 'lucky'
+    # integer value
+    assert dict_item({13: 7}, 13) is 7

--- a/ppa/archive/views.py
+++ b/ppa/archive/views.py
@@ -31,11 +31,14 @@ class DigitizedWorkListView(ListView):
 
     paginate_by = 50
 
+    # keyword query; assume no search terms unless set
+    query = None
+
     def get_queryset(self, **kwargs):
         self.form = SearchForm(self.request.GET)
-        query = join_q = collections = None
+        join_q = collections = None
         if self.form.is_valid():
-            query = self.form.cleaned_data.get("query", "")
+            self.query = self.form.cleaned_data.get("query", "")
             # NOTE: This allows us to get the name of collections for
             # collections_exact and set collections to a list of collection names
             collections = self.form.cleaned_data.get("collections", None)
@@ -54,15 +57,15 @@ class DigitizedWorkListView(ListView):
             filter_q.append('(%(coll)s OR {!join from=id to=srcid v=$coll_query})' \
                 % {'coll': coll_query})
 
-        if query:
+        if self.query:
             # simple keyword search across all text content
-            solr_q = join_q = "text:(%s)" % query
+            solr_q = join_q = "text:(%s)" % self.query
 
             # use join to ensure we always get the work if any pages match
             # using query syntax as documented at
             # http://comments.gmane.org/gmane.comp.jakarta.lucene.solr.user/95646
             # to support exact phrase searches
-            solr_q = 'text:(%s) OR {!join from=srcid to=id v=$join_query}' % query
+            solr_q = 'text:(%s) OR {!join from=srcid to=id v=$join_query}' % self.query
             # sort by relevance, return score for display
             self.sort = 'relevance'
             solr_sort = 'score desc'
@@ -91,13 +94,56 @@ class DigitizedWorkListView(ListView):
             'facet.field': [field for field in self.form.facet_fields],
             # default expand sort is score desc
             'expand': 'true',
-            'expand.rows': 10,   # number of items in the collapsed group, i.e pages to display
+            'expand.rows': 2,   # number of items in the collapsed group, i.e pages to display
             'join_query': join_q,
-            'coll_query': coll_query
-            # 'rows': 50  # override solr default of 10 results; display 50 at a time for now
+            'coll_query': coll_query,
+            # enable highlighting
+            'hl': True,
+            'hl.fl': 'content',
+            # override solr default of 10 results; display 50 at a time for now
+            # 'rows': 50
         })
 
         return self.solrq
+
+    def get_page_highlights(self, page_groups):
+         # If there is a keyword search, query Solr for matching pages
+        # with text highlighting.  Note that this has to be done as
+        # a separate query because Solr doesn't support highlighting on
+        # collapsed items.
+
+        page_highlights = {}
+        if not self.query or not page_groups:
+            # if there is no keyword query, bail out
+            return page_highlights
+
+        # generate a list of page ids from the grouped results
+        page_ids = [page['id'] for results in page_groups.values()
+                    for page in results['docs']]
+
+        if not page_ids:
+            # if no page ids were found, bail out
+            return page_highlights
+
+        # Query solr for the desired pages by id with the same
+        # keyword search.
+        # NOTE: This id query assumes OR is default; if  that changes,
+        # add an explicitly OR here between ids.
+        # NOTE 2: using quotes around ids to handle ids that include
+        # colons, e.g. ark:/foo/bar .
+        solr_pageq = PagedSolrQuery({
+            'q': 'text:(%s) AND id:(%s)' % \
+                (self.query, ' '.join('"%s"' % pid for pid in page_ids)),
+            # enable highlighting on content field with 3 snippets
+            'hl': True,
+            'hl.fl': 'content',
+            'hl.snippets': 3,
+            # use Unified Highlighter (not default but recommended)
+            'hl.method': 'unified',
+            # override solr default of 10 results to return all pages
+            'rows': len(page_ids)
+        })
+        return solr_pageq.get_highlighting()
 
     def get_context_data(self, **kwargs):
         page_groups = None
@@ -105,8 +151,11 @@ class DigitizedWorkListView(ListView):
             # catch an error querying solr when the search terms cannot be parsed
             # (e.g., incomplete exact phrase)
             context = super(DigitizedWorkListView, self).get_context_data(**kwargs)
-            page_groups = json.loads(self.solrq.get_json()).get('expanded', {})
+            # raw_solr_response = json.loads(self.solrq.get_json())
+            # page_groups = raw_solr_response.get('expanded', {})
+            page_groups = self.solrq.get_expanded()
             facet_dict = self.solrq.get_facets()
+
             self.form.set_choices_from_facets(facet_dict)
 
         except SolrError as solr_err:
@@ -121,8 +170,8 @@ class DigitizedWorkListView(ListView):
             'search_form': self.form,
             # total and object_list provided by paginator
             'sort': self.sort,
-            'page_groups': page_groups
-
+            'page_groups': page_groups,
+            'page_highlights': self.get_page_highlights(page_groups),
         })
         return context
 
@@ -152,8 +201,9 @@ class DigitizedWorkCSV(ListView):
     # order by id for now, for simplicity
     ordering = 'id'
     header_row = ['Database ID', 'Source ID', 'Title', 'Author',
-        'Publication Date', 'Publication Place', 'Publisher', 'Enumcron',
-        'Collection', 'Page Count', 'Date Added', 'Last Updated']
+                  'Publication Date', 'Publication Place', 'Publisher',
+                  'Enumcron', 'Collection', 'Page Count', 'Date Added',
+                  'Last Updated']
 
     def get_csv_filename(self):
         '''Return the CSV file name based on the current datetime.


### PR DESCRIPTION
Feature #31 

- adds convenience methods to local solr query object to provide access to expanded & highlighting results
- adds custom templatetag for getting a dict item from a variable key, to simplify templates for expanded results and highlights
- adds view logic to query solr for pages with highlighted terms; currently requesting 3 snippets, but we can revisit
- basic template display of page images and text snippets
- does not include page label included in Zeplin mockup because we don't have access to that in the current import/index
