### PR TITLE
Feature/hathi links

### DIFF
--- a/ppa/archive/models.py
+++ b/ppa/archive/models.py
@@ -346,16 +346,18 @@ class DigitizedWork(models.Model, Indexable):
 
                 pagefilename = os.path.join(self.hathi_content_dir, page.text_file_location)
                 with ht_zip.open(pagefilename) as pagefile:
-
-                    yield {
-                        'id': '%s.%s' % (self.source_id, page.text_file.sequence),
-                        'srcid': self.source_id,   # for grouping with work record
-                        'content': pagefile.read().decode('utf-8'),
-                        'order': page.order,
-                        'label': page.display_label,
-                        'tags': page.label.split(', ') if page.label else [],
-                        'item_type': 'page'
-                    }
+                    try:
+                        yield {
+                            'id': '%s.%s' % (self.source_id, page.text_file.sequence),
+                            'srcid': self.source_id,   # for grouping with work record
+                            'content': pagefile.read().decode('utf-8'),
+                            'order': page.order,
+                            'label': page.display_label,
+                            'tags': page.label.split(', ') if page.label else [],
+                            'item_type': 'page'
+                        }
+                    except StopIteration:
+                        return    
 
     def get_metadata(self, metadata_format):
         '''Get metadata for this item in the specified format.

--- a/ppa/archive/static/archive/scss/snippets/_preview-page.scss
+++ b/ppa/archive/static/archive/scss/snippets/_preview-page.scss
@@ -25,14 +25,14 @@
 
     .preview {
         margin-right: 1rem;
-        
+
         img {
             width: 180px;
         }
-        
+
         #digitized-work & { // larger size on digitized work page
             margin-right: 2rem;
-    
+
             img {
                 width: 225px;
             }
@@ -43,6 +43,13 @@
         flex: 1 1 auto;
         margin: 0 1rem;
 
+        .page-number {
+          font-size: 14px;
+          font-family: $pageFont;
+          color: $gold;
+
+        }
+        
         .snippet {
             font-size: 18px;
             font-family: $headerFont;
@@ -50,6 +57,8 @@
             line-height: normal;
         }
     }
+
+
 
     em {
         font-style: normal;

--- a/ppa/archive/static/archive/scss/snippets/_preview-page.scss
+++ b/ppa/archive/static/archive/scss/snippets/_preview-page.scss
@@ -44,12 +44,14 @@
         margin: 0 1rem;
 
         .page-number {
-          font-size: 14px;
-          font-family: $pageFont;
-          color: $gold;
 
+          a {
+            font-size: 14px;
+            font-family: $pageFont;
+            color: $gold;
+          }
         }
-        
+
         .snippet {
             font-size: 18px;
             font-family: $headerFont;

--- a/ppa/archive/templates/archive/snippets/page_preview.html
+++ b/ppa/archive/templates/archive/snippets/page_preview.html
@@ -10,15 +10,18 @@ Expected context variables:
 {% load ppa_tags %}
 <div class="page">
     <div class="preview">
-        <img src="{% page_image_url item_id page.order 225 %}"
-            srcset="{% page_image_url item_id page.order 450 %} 2x"
-            alt="page preview {{ forloop.counter }}"/>
+        <a href="http://babel.hathitrust.org/cgi/pt?id={{ item_id }};view=1up;seq={{ page.order }}"
+          target=_blank>
+          <img src="{% page_image_url item_id page.order 225 %}"
+              srcset="{% page_image_url item_id page.order 450 %} 2x"
+              alt="page preview {{ forloop.counter }}"/>
+        </a>
     </div>
     {% if page.title %}<a>p. {{ page.title }}</a>{% endif %}
     <div class="snippets">
+        <p class="page-number">p. {{ page.label }}</p>
         {% for snippet in highlights.content %}
         <p class="snippet">{{ snippet|solr_highlight }}</p>
         {% endfor %}
     </div>
 </div>
-

--- a/ppa/archive/templates/archive/snippets/page_preview.html
+++ b/ppa/archive/templates/archive/snippets/page_preview.html
@@ -19,7 +19,11 @@ Expected context variables:
     </div>
     {% if page.title %}<a>p. {{ page.title }}</a>{% endif %}
     <div class="snippets">
-        <p class="page-number">p. {{ page.label }}</p>
+          <p class="page-number">
+            <a href="{% page_url item_id page.order %}" target=_blank>
+              p. {{ page.label }}
+            </a>
+          </p>
         {% for snippet in highlights.content %}
         <p class="snippet">{{ snippet|solr_highlight }}</p>
         {% endfor %}

--- a/ppa/archive/templates/archive/snippets/page_preview.html
+++ b/ppa/archive/templates/archive/snippets/page_preview.html
@@ -10,7 +10,7 @@ Expected context variables:
 {% load ppa_tags %}
 <div class="page">
     <div class="preview">
-        <a href="http://babel.hathitrust.org/cgi/pt?id={{ item_id }};view=1up;seq={{ page.order }}"
+        <a href="{% page_url item_id page.order %}"
           target=_blank>
           <img src="{% page_image_url item_id page.order 225 %}"
               srcset="{% page_image_url item_id page.order 450 %} 2x"

--- a/ppa/archive/templatetags/ppa_tags.py
+++ b/ppa/archive/templatetags/ppa_tags.py
@@ -39,13 +39,21 @@ def querystring_replace(context, **kwargs):
     # return urlencoded query string
     return querystring.urlencode()
 
+#: Base url for HathiTrust assets
+HATHI_BASE_URL = 'https://babel.hathitrust.org/cgi'
+
+@register.simple_tag
+def page_url(item_id, order):
+    '''Generate a link to HathiTrust for an individual page
+    '''
+    return '{}/pt?id={};view=1up;seq={}'.format(HATHI_BASE_URL, item_id, order)
 
 @register.simple_tag
 def page_image_url(item_id, page, width):
     '''Generate a page image url based on an item id, page sequence label,
     and desired width. Currently HathiTrust specific.'''
-    return "https://babel.hathitrust.org/cgi/imgsrv/image?id={};seq={};width={}" \
-        .format(item_id, page, width)
+    return '{}/imgsrv/image?id={};seq={};width={}' \
+        .format(HATHI_BASE_URL, item_id, page, width)
 
 
 #: regular expression to identify open and close <em> tags in solr

--- a/ppa/archive/templatetags/ppa_tags.py
+++ b/ppa/archive/templatetags/ppa_tags.py
@@ -39,6 +39,8 @@ def querystring_replace(context, **kwargs):
     # return urlencoded query string
     return querystring.urlencode()
 
+# NOTE: Use urllib.parse? Not sure it gets us much given the semi-colon
+# delimited query strings.
 #: Base url for HathiTrust assets
 HATHI_BASE_URL = 'https://babel.hathitrust.org/cgi'
 
@@ -52,6 +54,8 @@ def page_image_url(item_id, order, width):
     '''
     return '{}/imgsrv/image?id={};seq={};width={}' \
         .format(HATHI_BASE_URL, item_id, order, width)
+
+        
 @register.simple_tag
 def page_url(item_id, order):
     '''Generate a link to HathiTrust for an individual page

--- a/ppa/archive/templatetags/ppa_tags.py
+++ b/ppa/archive/templatetags/ppa_tags.py
@@ -22,7 +22,7 @@ def dict_item(dictionary, key):
 def querystring_replace(context, **kwargs):
     '''Template tag to simplify retaining querystring parameters
     when paging through search results with active filters.
-    Example use:
+    Example use::
 
         <a href="?{% querystring_replace page=paginator.next_page_number %}">
     '''
@@ -43,17 +43,23 @@ def querystring_replace(context, **kwargs):
 HATHI_BASE_URL = 'https://babel.hathitrust.org/cgi'
 
 @register.simple_tag
+def page_image_url(item_id, order, width):
+    '''Generate a page image url based on an item id, page sequence label,
+    and desired width. Currently HathiTrust specific.
+    Example use::
+
+        {% page_image_url item_id page.order 220 %}
+    '''
+    return '{}/imgsrv/image?id={};seq={};width={}' \
+        .format(HATHI_BASE_URL, item_id, order, width)
+@register.simple_tag
 def page_url(item_id, order):
     '''Generate a link to HathiTrust for an individual page
+    Example use::
+
+        {% page_url item_id page.order %}
     '''
     return '{}/pt?id={};view=1up;seq={}'.format(HATHI_BASE_URL, item_id, order)
-
-@register.simple_tag
-def page_image_url(item_id, page, width):
-    '''Generate a page image url based on an item id, page sequence label,
-    and desired width. Currently HathiTrust specific.'''
-    return '{}/imgsrv/image?id={};seq={};width={}' \
-        .format(HATHI_BASE_URL, item_id, page, width)
 
 
 #: regular expression to identify open and close <em> tags in solr

--- a/ppa/archive/templatetags/ppa_tags.py
+++ b/ppa/archive/templatetags/ppa_tags.py
@@ -40,18 +40,12 @@ def querystring_replace(context, **kwargs):
     return querystring.urlencode()
 
 
-#: regular expression to extract page sequence from page order
-#: (could contain other content, but should end with numbers)
-PAGE_REQUENCE_RE = re.compile(r'[^\d]*(\d+)$')
-
-
 @register.simple_tag
 def page_image_url(item_id, page, width):
     '''Generate a page image url based on an item id, page sequence label,
     and desired width. Currently HathiTrust specific.'''
-    page_sequence = int(PAGE_REQUENCE_RE.search(page).group(1))
     return "https://babel.hathitrust.org/cgi/imgsrv/image?id={};seq={};width={}" \
-        .format(item_id, page_sequence, width)
+        .format(item_id, page, width)
 
 
 #: regular expression to identify open and close <em> tags in solr
@@ -83,5 +77,3 @@ def solr_highlight(value, autoescape=True):
 @register.filter(name='json')
 def json_dumps(data):
     return mark_safe(json.dumps(data))
-    
-

--- a/ppa/archive/tests/test_models.py
+++ b/ppa/archive/tests/test_models.py
@@ -287,16 +287,20 @@ class TestDigitizedWork(TestCase):
             assert isinstance(page_data, types.GeneratorType)
 
             for i, data in enumerate(page_data):
-                mets_page = mets.structmap_pages[i]
 
-                assert data['id'] == '.'.join([work.source_id, mets_page.text_file.sequence])
-                assert data['srcid'] == work.source_id
-                assert data['content'] == contents[i]
-                assert data['order'] == mets_page.order
-                assert data['item_type'] == 'page'
-                assert data['label'] == mets_page.display_label
-                assert 'tags' in data
-                assert data['tags'] == mets_page.label.split(', ')
+                    mets_page = mets.structmap_pages[i]
+
+                    assert data['id'] == '.'.join([work.source_id, mets_page.text_file.sequence])
+                    assert data['srcid'] == work.source_id
+                    assert data['content'] == contents[i]
+                    assert data['order'] == mets_page.order
+                    assert data['item_type'] == 'page'
+                    assert data['label'] == mets_page.display_label
+                    assert 'tags' in data
+                    assert data['tags'] == mets_page.label.split(', ')
+                    # fix behavior for upcoming PEP 479
+                    # https://www.python.org/dev/peps/pep-0479/
+                    yield
 
     def test_index_id(self):
         work = DigitizedWork(source_id='chi.79279237')

--- a/ppa/archive/tests/test_models.py
+++ b/ppa/archive/tests/test_models.py
@@ -287,9 +287,7 @@ class TestDigitizedWork(TestCase):
             assert isinstance(page_data, types.GeneratorType)
 
             for i, data in enumerate(page_data):
-
                 mets_page = mets.structmap_pages[i]
-
                 assert data['id'] == '.'.join([work.source_id, mets_page.text_file.sequence])
                 assert data['srcid'] == work.source_id
                 assert data['content'] == contents[i]
@@ -298,9 +296,7 @@ class TestDigitizedWork(TestCase):
                 assert data['label'] == mets_page.display_label
                 assert 'tags' in data
                 assert data['tags'] == mets_page.label.split(', ')
-                # fix behavior for upcoming PEP 479
-                # https://www.python.org/dev/peps/pep-0479/
-                yield
+
 
     def test_index_id(self):
         work = DigitizedWork(source_id='chi.79279237')

--- a/ppa/archive/tests/test_models.py
+++ b/ppa/archive/tests/test_models.py
@@ -288,19 +288,19 @@ class TestDigitizedWork(TestCase):
 
             for i, data in enumerate(page_data):
 
-                    mets_page = mets.structmap_pages[i]
+                mets_page = mets.structmap_pages[i]
 
-                    assert data['id'] == '.'.join([work.source_id, mets_page.text_file.sequence])
-                    assert data['srcid'] == work.source_id
-                    assert data['content'] == contents[i]
-                    assert data['order'] == mets_page.order
-                    assert data['item_type'] == 'page'
-                    assert data['label'] == mets_page.display_label
-                    assert 'tags' in data
-                    assert data['tags'] == mets_page.label.split(', ')
-                    # fix behavior for upcoming PEP 479
-                    # https://www.python.org/dev/peps/pep-0479/
-                    yield
+                assert data['id'] == '.'.join([work.source_id, mets_page.text_file.sequence])
+                assert data['srcid'] == work.source_id
+                assert data['content'] == contents[i]
+                assert data['order'] == mets_page.order
+                assert data['item_type'] == 'page'
+                assert data['label'] == mets_page.display_label
+                assert 'tags' in data
+                assert data['tags'] == mets_page.label.split(', ')
+                # fix behavior for upcoming PEP 479
+                # https://www.python.org/dev/peps/pep-0479/
+                yield
 
     def test_index_id(self):
         work = DigitizedWork(source_id='chi.79279237')

--- a/ppa/archive/tests/test_templatetags.py
+++ b/ppa/archive/tests/test_templatetags.py
@@ -6,7 +6,7 @@ from django.utils.safestring import SafeString, mark_safe
 import json
 
 from ppa.archive.templatetags.ppa_tags import dict_item, querystring_replace, \
-    page_image_url, solr_highlight, json_dumps
+    page_image_url, page_url, solr_highlight, json_dumps, HATHI_BASE_URL
 
 def test_dict_item():
     # no error on not found
@@ -46,23 +46,22 @@ def test_querystring_replace():
 
 
 def test_page_image_url():
-    # simple page id
+    # basic test with order, width, and item id
     item_id = "mdp.39015031594768"
-    page_id = "00000029"
-    page_seq = 29
+    order = 29
     width = 180
-    img_url = page_image_url(item_id, page_id, width)
-    print(img_url)
-    assert img_url.startswith("https://babel.hathitrust.org/cgi/imgsrv/image?")
-    assert img_url.endswith('image?id=%s;seq=%s;width=%s' % (item_id, page_seq, width))
+    img_url = page_image_url(item_id, order, width)
+    # points to the appropriate url
+    assert img_url.startswith("%s/imgsrv/image?" % HATHI_BASE_URL)
+    # renders the correct query string
+    assert img_url.endswith('image?id=%s;seq=%s;width=%s' % (item_id, order, width))
 
-    # page id with non-numeric characters
-    item_id = 'uc1.c2608792'
-    page_id = 'UCAL_C2608792_00000009'
-    page_seq = 9
-    img_url = page_image_url(item_id, page_id, width)
-    assert img_url.endswith('image?id=%s;seq=%s;width=%s' % (item_id, page_seq, width))
-
+def test_page_url():
+    item_id = "mdp.39015031594768"
+    order = 50
+    hathi_url = page_url(item_id, order)
+    assert hathi_url.startswith('%s/pt' % HATHI_BASE_URL)
+    assert hathi_url.endswith('?id=%s;view=1up;seq=%s' % (item_id, order))
 
 def test_solr_highlight():
     # simple text snippet

--- a/ppa/archive/tests/test_views.py
+++ b/ppa/archive/tests/test_views.py
@@ -228,11 +228,11 @@ class TestArchiveViews(TestCase):
             msg_prefix='has imgset src url'
         )
         self.assertContains(response, '1 occurrence')
-        # image should have a link to hathitrust
+        # image should have a link to hathitrust as should the page number
         self.assertContains(
             response,
             page_url(result['srcid'], result['order']),
-            count=1,
+            count=2,
             msg_prefix='should include a link to HathiTrust'
         )
 

--- a/ppa/archive/tests/test_views.py
+++ b/ppa/archive/tests/test_views.py
@@ -17,7 +17,7 @@ from ppa.archive.forms import SearchForm
 from ppa.archive.models import DigitizedWork, Collection
 from ppa.archive.solr import get_solr_connection, PagedSolrQuery
 from ppa.archive.views import DigitizedWorkCSV, DigitizedWorkListView, IndexView
-from ppa.archive.templatetags.ppa_tags import page_image_url
+from ppa.archive.templatetags.ppa_tags import page_image_url, page_url
 
 class TestArchiveViews(TestCase):
     fixtures = ['sample_digitized_works']
@@ -160,8 +160,8 @@ class TestArchiveViews(TestCase):
         ]
         htid = 'chi.78013704'
         solr_page_docs = [
-            {'content': content, 'order': i, 'item_type': 'page',
-             'srcid': htid, 'id': '%s.%s' % (htid, i)}
+            {'content': content, 'order': i+1, 'item_type': 'page',
+             'srcid': htid, 'id': '%s.%s' % (htid, i), 'label': i}
              for i, content in enumerate(sample_page_content)]
         dial = DigitizedWork.objects.get(source_id='chi.78013704')
         solr_work_docs = [dial.index_data()]
@@ -207,19 +207,35 @@ class TestArchiveViews(TestCase):
         highlights = response.context['page_highlights'][result['id']]
         # template has the expected information rendered
         self.assertContains(response, highlights['content'][0])
+        # page number that correspondeds to label field should be present
+        self.assertContains(
+            response,
+            'p. %s' % result['label'],
+            count=1,
+            msg_prefix='has page label for the print page numb.'
+        )
         # image url should appear twice for src and srcset
         self.assertContains(
             response,
             page_image_url(result['srcid'], result['order'], 225),
-            count=1
+            count=1,
+            msg_prefix='has img src url'
         )
         self.assertContains(
             response,
             page_image_url(result['srcid'], result['order'], 450),
-            count=1
+            count=1,
+            msg_prefix='has imgset src url'
         )
         self.assertContains(response, '1 occurrence')
-        # image should have a link to hathi
+        # image should have a link to hathitrust
+        self.assertContains(
+            response,
+            page_url(result['srcid'], result['order']),
+            count=1,
+            msg_prefix='should include a link to HathiTrust'
+        )
+
 
         # bad syntax
         response = self.client.get(url, {'query': '"incomplete phrase'})

--- a/ppa/archive/tests/test_views.py
+++ b/ppa/archive/tests/test_views.py
@@ -219,6 +219,7 @@ class TestArchiveViews(TestCase):
             count=1
         )
         self.assertContains(response, '1 occurrence')
+        # image should have a link to hathi
 
         # bad syntax
         response = self.client.get(url, {'query': '"incomplete phrase'})

--- a/ppa/archive/views.py
+++ b/ppa/archive/views.py
@@ -313,7 +313,7 @@ class DigitizedWorkDetailView(DetailView):
                 # sort by page order by default
                 'sort': 'order asc',
                 # 'fl': '*',
-                'fl': 'id,srcid,order,title',  # Limiting down to just id needed for now
+                'fl': 'id,srcid,order,title,label',  # Limiting only to needed fields
                 'fq': 'srcid:("%s") AND item_type:page' % digwork.source_id,
                 # configure highlighting on page text content
                 'hl': True,


### PR DESCRIPTION
* Adds template tag to render Hathi page links using the order attribute of solr page objects
* Adds and styled page reference via `page.label` per Zepplin
* Refactors tags for `page_url` and `page_image_url`