### PR TITLE
Feature/add vary headers

### DIFF
--- a/ppa/archive/views.py
+++ b/ppa/archive/views.py
@@ -16,18 +16,19 @@ from SolrClient.exceptions import SolrError
 from ppa.archive.forms import SearchForm, AddToCollectionForm, SearchWithinWorkForm
 from ppa.archive.models import DigitizedWork, Collection
 from ppa.archive.solr import get_solr_connection, PagedSolrQuery
-
+from ppa.common.views import VaryOnHeadersMixin
 
 logger = logging.getLogger(__name__)
 
 
-class DigitizedWorkListView(ListView):
+class DigitizedWorkListView(ListView, VaryOnHeadersMixin):
     '''Search and browse digitized works.  Based on Solr index
     of works and pages.'''
 
     template_name = 'archive/list_digitizedworks.html'
     form_class = SearchForm
     paginate_by = 50
+    vary_headers = ['X-Requested-With']
 
     # keyword query; assume no search terms unless set
     query = None

--- a/ppa/common/tests.py
+++ b/ppa/common/tests.py
@@ -33,7 +33,7 @@ class TestVaryOnHeadersMixin(TestCase):
         # stub a View that will always return 405 since no methods are defined
         vary_on_view = \
             VaryOnHeadersMixin(vary_headers=['X-Foobar', 'X-Bazbar'])
-        # mock a request because we don't need it's functionality
+        # mock a request because we don't need its functionality
         request = Mock()
         response = vary_on_view.dispatch(request)
         # check for the set header with the values supplied

--- a/ppa/common/tests.py
+++ b/ppa/common/tests.py
@@ -1,7 +1,10 @@
+from unittest.mock import Mock
+
 from django.contrib.auth.models import User, Group
 from django.test import TestCase
 
 from ppa.common.admin import LocalUserAdmin
+from ppa.common.views import VaryOnHeadersMixin
 
 
 class TestLocalUserAdmin(TestCase):
@@ -22,3 +25,16 @@ class TestLocalUserAdmin(TestCase):
         assert grp2.name in group_names
         assert grp3.name not in group_names
 
+
+class TestVaryOnHeadersMixin(TestCase):
+
+    def test_vary_on_headers_mixing(self):
+
+        # stub a View that will always return 405 since no methods are defined
+        vary_on_view = \
+            VaryOnHeadersMixin(vary_headers=['X-Foobar', 'X-Bazbar'])
+        # mock a request because we don't need it's functionality
+        request = Mock()
+        response = vary_on_view.dispatch(request)
+        # check for the set header with the values supplied
+        assert response['Vary'] == 'X-Foobar, X-Bazbar'

--- a/ppa/common/views.py
+++ b/ppa/common/views.py
@@ -1,0 +1,19 @@
+from django.utils.cache import patch_vary_headers
+from django.views.generic.base import View
+
+
+class VaryOnHeadersMixin(View):
+    '''View mixin to set Vary header - class-based view equivalent to
+    :meth:`django.views.decorators.vary.vary_on_headers`, adapted from
+    winthrop-django.
+
+    Define :attr:`vary_headers` with the list of headers.
+    '''
+
+    vary_headers = []
+
+    def dispatch(self, request, *args, **kwargs):
+        '''wrap default dispatch method to patch haeders on the response'''
+        response = super(VaryOnHeadersMixin, self).dispatch(request, *args, **kwargs)
+        patch_vary_headers(response, self.vary_headers)
+        return response


### PR DESCRIPTION
This request resolves the caching issue that produces #125 error by copying (and testing) the `VaryOnHeadersMixin` from `winthrop-django`.