### PR TITLE
Strip hyperlinks (and some other html) from description text for editorial pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2751,7 +2751,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",

--- a/ppa/pages/models.py
+++ b/ppa/pages/models.py
@@ -123,7 +123,8 @@ class PagePreviewDescriptionMixin(models.Model):
 
     # ('a' is omitted by subsetting and p is added to default ALLOWED_TAGS)
     #: allowed tags for bleach html stripping in description
-    allowed_tags = bleach.sanitizer.ALLOWED_TAGS[1:] + ['p']
+    allowed_tags = list((set(bleach.sanitizer.ALLOWED_TAGS) |
+                        set(['p'])) - set(['a']))
 
     class Meta:
         abstract = True

--- a/ppa/pages/models.py
+++ b/ppa/pages/models.py
@@ -1,3 +1,4 @@
+import bleach
 from django.db import models
 from django.template.defaultfilters import truncatechars_html, striptags
 from wagtail.core import blocks
@@ -103,7 +104,7 @@ class BodyContentBlock(blocks.StreamBlock):
     '''Common set of content blocks to be used on both content pages
     and editorial pages'''
     paragraph = blocks.RichTextBlock()
-    image  =  ImageChooserBlock()
+    image = ImageChooserBlock()
     document = DocumentChooserBlock()
 
 
@@ -119,6 +120,10 @@ class PagePreviewDescriptionMixin(models.Model):
 
     #: maximum length for description to be displayed
     max_length = 250
+
+    # ('a' is omitted by subsetting and p is added to default ALLOWED_TAGS)
+    #: allowed tags for bleach html stripping in description
+    allowed_tags = bleach.sanitizer.ALLOWED_TAGS[1:] + ['p']
 
     class Meta:
         abstract = True
@@ -143,6 +148,11 @@ class PagePreviewDescriptionMixin(models.Model):
                     # break so we stop after the first instead of using last
                     break
 
+        description = bleach.clean(
+            str(description),
+            tags=self.allowed_tags,
+            strip=True
+        )
         # truncate either way
         return truncatechars_html(description, self.max_length)
 

--- a/ppa/pages/tests/test_models.py
+++ b/ppa/pages/tests/test_models.py
@@ -158,7 +158,8 @@ class TestContentPage(WagtailPageTests):
         assert desc[:200] == bleach.clean(
             str(content_page.body[0]),
             # omit 'a' from list of allowed tags
-            tags=bleach.sanitizer.ALLOWED_TAGS[1:] + ['p'],
+            tags=list((set(bleach.sanitizer.ALLOWED_TAGS) |
+                       set(['p'])) - set(['a'])),
             strip=True
         )[:200]
         # empty tags in description shouldn't be used
@@ -181,7 +182,8 @@ class TestContentPage(WagtailPageTests):
             bleach.clean(
                 str(content_page2.body[1]),
                 # omit 'a' from list of allowed tags
-                tags=bleach.sanitizer.ALLOWED_TAGS[1:] + ['p'],
+                tags=list((set(bleach.sanitizer.ALLOWED_TAGS) |
+                          set(['p'])) - set(['a'])),
                 strip=True
             )[:200]
 

--- a/ppa/pages/tests/test_models.py
+++ b/ppa/pages/tests/test_models.py
@@ -1,3 +1,4 @@
+import bleach
 from time import sleep
 
 from django.contrib.contenttypes.models import ContentType
@@ -147,29 +148,45 @@ class TestContentPage(WagtailPageTests):
 
         assert not content_page.description
         desc = content_page.get_description()
+        print(desc)
         # length excluding tags should be truncated to max length or less
         assert len(striptags(desc)) <= content_page.max_length
         # beginning of text should match exactly the *first* block
         # (excluding end of content because truncation is inside tags)
-        assert desc[:200] == str(content_page.body[0])[:200]
 
+        # should also be cleaned by bleach to its limited set of tags
+        assert desc[:200] == bleach.clean(
+            str(content_page.body[0]),
+            # omit 'a' from list of allowed tags
+            tags=bleach.sanitizer.ALLOWED_TAGS[1:] + ['p'],
+            strip=True
+        )[:200]
         # empty tags in description shouldn't be used
         content_page.description = '<p></p>'
         desc = content_page.get_description()
-        assert desc[:200] == str(content_page.body[0])[:200]
+
 
         # test content page with image for first block
         content_page2 = ContentPage(
             title='What is Prosody?',
             body=[
                 ('image', '<img src="milton-example.png"/>'),
-                ('paragraph', '<p>Prosody today means both the study of versification and pronunciation</p>'),
+                ('paragraph', '<p>Prosody today means both the study of '
+                              'and <a href="#">pronunciation</a></p>'),
                 ('paragraph', '<p>More content here...</p>'),
             ]
         )
         # should ignore image block and use first paragraph content
         assert content_page2.get_description()[:200] == \
-            str(content_page2.body[1])[:200]
+            bleach.clean(
+                str(content_page2.body[1]),
+                # omit 'a' from list of allowed tags
+                tags=bleach.sanitizer.ALLOWED_TAGS[1:] + ['p'],
+                strip=True
+            )[:200]
+
+        # should remove <a> tags
+        assert '<a href="#">' not in content_page2.get_description()
 
         # should use description field when set
         content_page2.description = '<p>A short intro to prosody.</p>'
@@ -179,6 +196,9 @@ class TestContentPage(WagtailPageTests):
         content_page2.description = content_page.body[0]
         assert len(striptags(content_page.get_description())) \
             <= content_page.max_length
+
+
+
 
     def test_get_plaintext_description(self):
         # description set but no search description

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ django-compressor-toolkit
 lxml
 eulxml
 wagtail>=2.3
+bleach


### PR DESCRIPTION
This PR:

- Adds bleach as a dependency
- uses it to strip hyperlinks and other HTML other than its default safe set (minus `<a>`) from descriptions used in editorial index page.
