### PR TITLE
Feature/csp

### DIFF
--- a/ppa/local_settings.py.sample
+++ b/ppa/local_settings.py.sample
@@ -114,11 +114,6 @@ LOGGING = {
     }
 }
 
-# URL to POST reports of content security policy violations to
 # https://github.com/mozilla/django-csp
-
-if not DEBUG: # don't report in debug mode
-    if CSP_REPORT_ONLY:
-        CSP_REPORT_URI = '' # url for 'report-only' mode
-    else:
-        CSP_REPORT_URI = '' # url for blocked violations
+# URL to POST reports of content security policy violations to
+CSP_REPORT_URI = ''

--- a/ppa/local_settings.py.sample
+++ b/ppa/local_settings.py.sample
@@ -113,3 +113,12 @@ LOGGING = {
 
     }
 }
+
+# URL to POST reports of content security policy violations to
+# https://github.com/mozilla/django-csp
+
+if not DEBUG: # don't report in debug mode
+    if CSP_REPORT_ONLY:
+        CSP_REPORT_URI = '' # url for 'report-only' mode
+    else:
+        CSP_REPORT_URI = '' # url for blocked violations

--- a/ppa/local_settings.py.sample
+++ b/ppa/local_settings.py.sample
@@ -115,5 +115,9 @@ LOGGING = {
 }
 
 # https://github.com/mozilla/django-csp
-# URL to POST reports of content security policy violations to
-CSP_REPORT_URI = ''
+# Content security policy controls - see `settings.py` for policy settings.
+# In development, leave both lines commented out to block & not report.
+# In QA, set REPORT_ONLY to True and specify a "report-only" endpoint.
+# In production, set REPORT_ONLY to False and specify an "enforced" endpoint.
+# CSP_REPORT_ONLY = False
+# CSP_REPORT_URI = ''

--- a/ppa/settings.py
+++ b/ppa/settings.py
@@ -259,7 +259,8 @@ PUCAS_LDAP = {
 CSP_DEFAULT_SRC = "'none'"
 
 # allow loading js locally, from a cdn, and from google (for analytics)
-CSP_SCRIPT_SRC = ("'self'", 'https://cdnjs.cloudflare.com', 'https://www.googletagmanager.com')
+CSP_SCRIPT_SRC = ("'self'", 'https://cdnjs.cloudflare.com',
+                  'https://www.googletagmanager.com')
 
 # allow loading fonts locally and from google (via data: url)
 CSP_FONT_SRC = ("'self'", 'https://fonts.gstatic.com data:')
@@ -267,8 +268,9 @@ CSP_FONT_SRC = ("'self'", 'https://fonts.gstatic.com data:')
 # allow loading css locally and from google (for fonts)
 CSP_STYLE_SRC = ("'self'", 'https://fonts.googleapis.com')
 
-# allow loading images locally, from hathi (for page images) and google tracking pixel
-CSP_IMG_SRC = ("'self'", 'https://babel.hathitrust.org', 'https://www.google-analytics.com')
+# allow loading local images, hathi page images, google tracking pixel
+CSP_IMG_SRC = ("'self'", 'https://babel.hathitrust.org',
+               'https://www.google-analytics.com')
 
 # exclude admin and cms urls from csp directives since they're authenticated
 CSP_EXCLUDE_URL_PREFIXES = ('/admin', '/cms')
@@ -309,4 +311,3 @@ if DEBUG:
         MIDDLEWARE.append('debug_toolbar.middleware.DebugToolbarMiddleware')
     except ImportError:
         pass
-

--- a/ppa/settings.py
+++ b/ppa/settings.py
@@ -255,8 +255,8 @@ PUCAS_LDAP = {
 # django-csp configuration for content security policy definition and
 # violation reporting - https://github.com/mozilla/django-csp
 
-# allow loading js locally and from a cdn (for jQuery and other libraries)
-CSP_SCRIPT_SRC = ("'self'", 'https://cdnjs.cloudflare.com')
+# allow loading js locally, from a cdn, and from google (for analytics)
+CSP_SCRIPT_SRC = ("'self'", 'https://cdnjs.cloudflare.com', 'https://www.googletagmanager.com')
 
 # allow loading fonts locally and from google (via data: url)
 CSP_FONT_SRC = ("'self'", 'https://fonts.gstatic.com data:')
@@ -269,6 +269,9 @@ CSP_IMG_SRC = ("'self'", 'https://babel.hathitrust.org')
 
 # exclude admin and cms urls from csp directives since they're authenticated
 CSP_EXCLUDE_URL_PREFIXES = ('/admin', '/cms')
+
+# allow usage of nonce for inline js (for analytics)
+CSP_INCLUDE_NONCE_IN = ('script-src',)
 
 ##################
 # LOCAL SETTINGS #

--- a/ppa/settings.py
+++ b/ppa/settings.py
@@ -255,6 +255,9 @@ PUCAS_LDAP = {
 # django-csp configuration for content security policy definition and
 # violation reporting - https://github.com/mozilla/django-csp
 
+# fallback for all protocols: block it
+CSP_DEFAULT_SRC = "'none'"
+
 # allow loading js locally, from a cdn, and from google (for analytics)
 CSP_SCRIPT_SRC = ("'self'", 'https://cdnjs.cloudflare.com', 'https://www.googletagmanager.com')
 
@@ -264,8 +267,8 @@ CSP_FONT_SRC = ("'self'", 'https://fonts.gstatic.com data:')
 # allow loading css locally and from google (for fonts)
 CSP_STYLE_SRC = ("'self'", 'https://fonts.googleapis.com')
 
-# allow loading images locally and from hathi (for page images)
-CSP_IMG_SRC = ("'self'", 'https://babel.hathitrust.org')
+# allow loading images locally, from hathi (for page images) and google tracking pixel
+CSP_IMG_SRC = ("'self'", 'https://babel.hathitrust.org', 'https://www.google-analytics.com')
 
 # exclude admin and cms urls from csp directives since they're authenticated
 CSP_EXCLUDE_URL_PREFIXES = ('/admin', '/cms')

--- a/ppa/settings.py
+++ b/ppa/settings.py
@@ -126,6 +126,7 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
+    'csp.middleware.CSPMiddleware',
 ]
 
 AUTHENTICATION_BACKENDS = (
@@ -251,7 +252,23 @@ PUCAS_LDAP = {
     },
 }
 
+# django-csp configuration for content security policy definition and
+# violation reporting - https://github.com/mozilla/django-csp
 
+# allow loading js locally and from a cdn (for jQuery and other libraries)
+CSP_SCRIPT_SRC = ("'self'", 'https://cdnjs.cloudflare.com')
+
+# allow loading fonts locally and from google (via data: url)
+CSP_FONT_SRC = ("'self'", 'https://fonts.gstatic.com data:')
+
+# allow loading css locally and from google (for fonts)
+CSP_STYLE_SRC = ("'self'", 'https://fonts.googleapis.com')
+
+# allow loading images locally and from hathi (for page images)
+CSP_IMG_SRC = ("'self'", 'https://babel.hathitrust.org')
+
+# exclude admin and cms urls from csp directives since they're authenticated
+CSP_EXCLUDE_URL_PREFIXES = ('/admin', '/cms')
 
 ##################
 # LOCAL SETTINGS #

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ eulxml
 wagtail>=2.3
 bleach
 django-fullurl
+django-csp

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ django-compressor
 django-compressor-toolkit
 lxml
 eulxml
-wagtail>=2.3
+wagtail>=2.3,<2.4
 bleach
 django-fullurl
 django-csp

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -40,5 +40,9 @@
         });
     })(grp.jQuery);
     </script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script
+        src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"
+        integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+        crossorigin="anonymous">
+    </script>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -52,10 +52,15 @@ by default; use page_rdf_type to override with a webpage subclass.
 
     <!-- scripts -->
     <script
-    src="https://code.jquery.com/jquery-3.1.1.min.js"
-    integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8="
-    crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/bodymovin/5.4.2/lottie_light.min.js"></script>
+        src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"
+        integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+        crossorigin="anonymous">
+    </script>
+    <script
+        src="https://cdnjs.cloudflare.com/ajax/libs/bodymovin/5.4.2/lottie_light.min.js"
+        integrity="sha256-9W89GVg8IxmHBVQSCtQx0Sxkk2lQdScemvga5wLSEcQ="
+        crossorigin="anonymous">
+    </script>
     <script src="{% static 'semantic/dist/semantic.min.js' %}"></script>
     {% if not request.is_preview and GTAGS_ANALYTICS_ID %}
         {% include 'snippets/analytics.html' %}

--- a/templates/snippets/analytics.html
+++ b/templates/snippets/analytics.html
@@ -1,7 +1,7 @@
 {% load static %}
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ GTAGS_ANALYTICS_ID }}"></script>
-<script>
+<script nonce="{{ request.csp_nonce }}">
     /*
       Google Analytics gtags snippet to be included if analytics are enabled.
     */


### PR DESCRIPTION
Would love comments on the way this is set up with settings/local_settings/etc.

You can access https://report-uri.com/ using the credentials in our google drive credentials document to check out some example reports. They provide different endpoints depending on if we're in 'report-only' or 'enforce' mode; I added space for both in the default local_settings. In DEBUG we don't report (for local dev).

This configuration is working for me so far (PPA seems to function); some inline js and styles are being blocked but I *think* that's just my browser extensions. Haven't tested page images because my reindex isn't done yet.