### PR TITLE
Feature/keyboard nav

### DIFF
--- a/srcmedia/js/index.js
+++ b/srcmedia/js/index.js
@@ -1,4 +1,5 @@
 import PitBar from './pitbar'
+import NavMenu from './modules/NavMenu'
 
 $(function(){
 
@@ -7,9 +8,12 @@ $(function(){
     const $mobileNav = $('#mobile-nav')
     const $menuButton = $('.toc.item')
     const $mobileDropdown = $('#mobile-nav .dropdown.item')
+    const $aboutMenu = $('.about')
+    const $aboutMenuText = $('.about > .text')
 
     /* bindings */
     let pb = new PitBar($mainNav, $mobileNav)
+    let an = new NavMenu($aboutMenu, $aboutMenuText)
 
     $mobileNav
         .sidebar('attach events', $menuButton)
@@ -24,5 +28,7 @@ $(function(){
         })
 
     $mobileDropdown.click(() => $mobileDropdown.toggleClass('active'))
+
+
 })
 

--- a/srcmedia/js/modules/NavMenu.js
+++ b/srcmedia/js/modules/NavMenu.js
@@ -1,0 +1,53 @@
+export default class AboutNav {
+    constructor(selector, textSelector) {
+
+        let self = this
+        self.$aboutMenu = $(selector)
+        self.$textSelector = $(textSelector)
+
+        // bind a listener for focusinout and file hover for semanticui
+        // css so that the menu appears for tab navigation
+        self.$aboutMenu.focusin(() => self.$aboutMenu.addClass('hovered'))
+        self.$aboutMenu.focusout(() => self.$aboutMenu.removeClass('hovered'))
+
+        // also enable for keypresses on up and down to move up and down the
+        // menu
+        self.$aboutMenu.keydown(self.keydownHandler.bind(self))
+
+    }
+
+    keydownHandler(ev) {
+        // if down arrow, target the next link element
+        if (ev.keyCode === 40) {
+            // using raw JS to determine we're on a link element
+            if (ev.target.nodeName === 'A') {
+                // if on a link, get its parent, next sibling, and child a element
+                // and focus
+                $(ev.target).parent().next().children('a').focus()
+            } else {
+                // if on the 'about' text itself, get its sibling div .menu
+                // child divs, first, and then focus on its a element
+                $(ev.target)
+                    .siblings('.menu')
+                    .children('div')
+                    .first()
+                    .children('a')
+                    .focus()
+            }
+        }
+        // if up arrow, target the previous link element or about menu text
+        if (ev.keyCode === 38) {
+            // check if there's a previous link
+            const $nextLink = $(ev.target).parent().prev().children('a')
+            // if there isn't, target the about text that has tabindex for
+            // menu
+            if ($nextLink.length === 0) {
+                this.$textSelector.focus()
+            } else {
+                // otherwise target the previous link
+                $nextLink.focus()
+            }
+        }
+    }
+
+}

--- a/srcmedia/js/modules/NavMenu.js
+++ b/srcmedia/js/modules/NavMenu.js
@@ -1,4 +1,12 @@
 export default class AboutNav {
+    /**
+     * Binds a keyboard navigation events using tab and
+     * up/down arrow keys to a CSS element structured as a
+     * semantic ui menu.
+     *
+     * @param {any} selector - JQuery or CSS selector for menu div
+     * @param {any} textSelector - JQuery or CSS selector for menu text div (i.e. name of menu)
+    */
     constructor(selector, textSelector) {
 
         let self = this
@@ -15,7 +23,11 @@ export default class AboutNav {
         self.$aboutMenu.keydown(self.keydownHandler.bind(self))
 
     }
-
+    /**
+     * Handler for keydown events on menu items.
+     *
+     * @param {jQuery.Event} ev - a jQuery keydown event
+    */
     keydownHandler(ev) {
         // if down arrow, target the next link element
         if (ev.keyCode === 40) {

--- a/srcmedia/scss/snippets/_nav.scss
+++ b/srcmedia/scss/snippets/_nav.scss
@@ -16,7 +16,7 @@
     }
 
     .item a {
-        text-decoration: none; 
+        text-decoration: none;
     }
 }
 
@@ -118,17 +118,17 @@
 
             &.hidden {
                 pointer-events: none;
-                
+
                 @media (max-width: $tablet) {
                     opacity: 0;
                 }
             }
-    
+
             &:hover {
                 border: none;
                 padding: 0;
             }
-    
+
             img {
                 position: relative;
                 width: 150px;
@@ -137,7 +137,7 @@
             }
         }
     }
-    
+
     .item {
         z-index: 1;
         display: none;
@@ -149,6 +149,20 @@
 
         &.about {
             padding-right: 10px; // avoid placement of triangle over icon
+            &.hovered {
+                > .icon {
+                    transform: rotate(-90deg);
+                }
+
+                > .menu {
+                    overflow: visible;
+                    width: auto;
+                    height: auto;
+                    top: 100%!important;
+                    opacity: 1;
+                }
+
+            }
         }
 
         &.toc,
@@ -165,10 +179,10 @@
             font-weight: bold;
         }
 
-        &.about.triangle::before { 
+        &.about.triangle::before {
             @include triangle-overlay($rosy-pink);
         }
-        
+
         &.editorial.active::before {
             @include triangle-overlay($twilight);
         }

--- a/srcmedia/test/fixtures/nav-menu.html
+++ b/srcmedia/test/fixtures/nav-menu.html
@@ -1,0 +1,11 @@
+<div class="about ui simple item dropdown triangle">
+    <div tabindex=0 class="text">About</div>
+    <div class="menu">
+        <div class="item"><a href="/history/">History of the Archive</a></div>
+        <div class="item"><a href="/prosody/">What is Prosody?</a></div>
+        <div class="item"><a href="/search/">How to Search</a></div>
+        <div class="item"><a href="/cite/">How to Cite</a></div>
+        <div class="item"><a href="/contributors/">Contributors and Board Members</a></div>
+        <div class="item"><a href="/contact/">Contact Us</a></div>
+    </div>
+</div>

--- a/srcmedia/test/unit/NavMenu.spec.js
+++ b/srcmedia/test/unit/NavMenu.spec.js
@@ -1,0 +1,78 @@
+import NavMenu from '../../js/modules/NavMenu.js'
+
+jasmine.getFixtures().fixturesPath = 'base/srcmedia/test/fixtures/'
+
+describe('NavMenu', () => {
+
+
+
+    describe('constructor()', () => {
+
+        beforeEach(function () {
+            loadFixtures('nav-menu.html')
+            this.an = new NavMenu('.about', '.about > .text')
+        })
+
+        it('binds selectors to self as jQuery objects', function() {
+            expect(this.an.$aboutMenu[0]).toBe($('.about')[0])
+            expect(this.an.$textSelector[0]).toBe($('.about > .text')[0])
+        })
+
+        it('binds handler for adding/removing hovered class', function() {
+            expect(this.an.$aboutMenu.hasClass('hovered')).toBeFalsy()
+            this.an.$aboutMenu.focusin()
+            expect(this.an.$aboutMenu.hasClass('hovered')).toBeTruthy()
+            this.an.$aboutMenu.focusout()
+            expect(this.an.$aboutMenu.hasClass('hovered')).toBeFalsy()
+        })
+
+        it('binds handler to keypress event for $aboutMenu', function() {
+            // minimal test to ensure binding happened
+            const e = $.Event('keydown')
+            e.keyCode = 40
+            this.an.$textSelector.trigger(e)
+            expect($(':focus').length).toBe(1)
+        })
+
+    })
+
+    describe('feedbackHandler()', () => {
+
+        beforeEach(function () {
+            loadFixtures('nav-menu.html')
+            this.an = new NavMenu('.about', '.about > .text')
+        })
+
+        it('moves up and down the menu based on arrow keys', function() {
+            const down = 40
+            const up = 38
+            const e = $.Event('keydown',
+                {
+                    keyCode: down,
+                    // set about as currentTarget and target for initial state
+                    currentTarget: document.getElementsByClassName('.about')[0],
+                    target: document.getElementsByClassName('.about')[0]
+                }
+            )
+            // start at about and walk down two
+            this.an.$textSelector.trigger(e)
+            expect($(':focus').attr('href')).toBe('/history/')
+            // get current focused DOM node and simulate the keydown correctly
+            e.target = $(':focus').get(0)
+            this.an.$textSelector.trigger(e)
+            expect($(':focus').attr('href')).toBe('/prosody/')
+            // now walk back up
+            e.keyCode = up
+            e.target = $(':focus').get(0)
+            $(':focus').trigger(e)
+            expect($(':focus').attr('href')).toBe('/history/')
+            e.target = $(':focus').get(0)
+            this.an.$textSelector.trigger(e)
+            // back to text (about)
+            expect($(':focus').hasClass('text')).toBeTruthy()
+
+
+        })
+    })
+
+})

--- a/templates/snippets/about.html
+++ b/templates/snippets/about.html
@@ -1,7 +1,7 @@
 {% load static %}
 
 <div class="about ui simple item dropdown{% if active == 'about' %} triangle{% endif %}">
-    <div class="text">About</div>
+    <div tabindex=0 class="text">About</div>
     <img class="dropdown icon" src="{% static 'img/icons/RightChevron.svg' %}" alt="">
     <div class="menu">
         {# NOTE: currently relies on editorial not having show_in_menu set #}


### PR DESCRIPTION
This PR adds keyboard and tab navigation to the `About` menu, refactored as a `NavMenu` class that could in theory be re-useable on other Semantic menus. Unit tests and documentation included.