### PR TITLE
Add new HathiTrust items from Django admin

### DIFF
--- a/ppa/archive/admin.py
+++ b/ppa/archive/admin.py
@@ -1,3 +1,4 @@
+from django.conf.urls import url
 from django.contrib import admin
 from django.http import HttpResponseRedirect
 from django.urls import reverse
@@ -5,6 +6,7 @@ from django.utils.safestring import mark_safe
 
 from ppa.archive.models import DigitizedWork, Collection, \
     ProtectedWorkFieldFlags
+from ppa.archive.views import AddFromHathiView
 
 
 class DigitizedWorkAdmin(admin.ModelAdmin):
@@ -110,6 +112,15 @@ class DigitizedWorkAdmin(admin.ModelAdmin):
 
     bulk_add_collection.short_description = ('Add selected digitized works '
                                              'to collections')
+
+    def get_urls(self):
+        urls = super(DigitizedWorkAdmin, self).get_urls()
+        my_urls = [
+            url(r'^add-hathi/$',
+                self.admin_site.admin_view(AddFromHathiView.as_view()),
+                name='add-from-hathi'),
+        ]
+        return my_urls + urls
 
 
 class CollectionAdmin(admin.ModelAdmin):

--- a/ppa/archive/forms.py
+++ b/ppa/archive/forms.py
@@ -401,13 +401,18 @@ class AddToCollectionForm(forms.Form):
 
 
 class AddFromHathiForm(forms.Form):
+    '''Form to input HathiTrust IDs for items to be added.'''
     hathi_ids = forms.CharField(
         label='HathiTrust Identifiers',
         required=True, widget=forms.Textarea,
-        help_text='List of Hathi IDs for items to add, one per line. '  + \
+        help_text='List of HathiTrust IDs for items to add, one per line. '  + \
             'Existing records and invalid IDs will be skipped.'
     )
 
-    # def get_hathi_ids(self):
-
+    def get_hathi_ids(self):
+        '''Get list of ids from valid form input. Splits on newlines,
+        strips whitespace, and ignores empty lines.'''
+        return [line.strip()
+                for line in self.cleaned_data['hathi_ids'].split('\n')
+                if line.strip()]
 

--- a/ppa/archive/forms.py
+++ b/ppa/archive/forms.py
@@ -415,4 +415,3 @@ class AddFromHathiForm(forms.Form):
         return [line.strip()
                 for line in self.cleaned_data['hathi_ids'].split('\n')
                 if line.strip()]
-

--- a/ppa/archive/forms.py
+++ b/ppa/archive/forms.py
@@ -398,3 +398,16 @@ class AddToCollectionForm(forms.Form):
         required=True, queryset=Collection.objects.all().order_by('name'),
         help_text='Hold down ctrl or command key (on MacOS) to select '
                   'multiple collections.')
+
+
+class AddFromHathiForm(forms.Form):
+    hathi_ids = forms.CharField(
+        label='HathiTrust Identifiers',
+        required=True, widget=forms.Textarea,
+        help_text='List of Hathi IDs for items to add, one per line. '  + \
+            'Existing records and invalid IDs will be skipped.'
+    )
+
+    # def get_hathi_ids(self):
+
+

--- a/ppa/archive/models.py
+++ b/ppa/archive/models.py
@@ -588,7 +588,6 @@ class DigitizedWork(TrackChangesModel, Indexable):
             'order': '0',
         }
 
-
     def count_pages(self, ptree_client=None):
         '''Count the number of pages for a digitized work based on the
         number of files in the zipfile within the pairtree content.
@@ -602,7 +601,10 @@ class DigitizedWork(TrackChangesModel, Indexable):
         start = time.time()
         # could raise pairtree exception, but allow calling context to catch
         with ZipFile(self.hathi.zipfile_path(ptree_client)) as ht_zip:
-            page_count = len(ht_zip.namelist())
+            # some aggregate packages retrieved from Data API
+            # include jp2 and xml files as well as txt; only count text
+            page_count = len([filename for filename in ht_zip.namelist()
+                              if filename.endswith('.txt')])
             logger.debug('Counted %d pages in zipfile in %f sec',
                          page_count, time.time() - start)
         # NOTE: could also count pages via mets file, but that's slower

--- a/ppa/archive/templates/admin/archive/digitizedwork/change_list.html
+++ b/ppa/archive/templates/admin/archive/digitizedwork/change_list.html
@@ -3,5 +3,7 @@
 
 {% block object-tools-items %}
     <li><a href="{% url 'archive:csv' %}" class="grp-state-focus">Download as CSV</a></li>
+    <li><a href="{% url 'admin:add-from-hathi' %}"
+        class="grp-add-link grp-state-focus">Add from HathiTrust</a></li>
     {{ block.super }}
 {% endblock %}

--- a/ppa/archive/templates/archive/add_from_hathi.html
+++ b/ppa/archive/templates/archive/add_from_hathi.html
@@ -1,0 +1,63 @@
+{% extends 'admin/base_site.html'  %}
+{% load i18n grp_tags ppa_tags %}
+{% block title %} {{ page_title }} | {% get_site_title %} {% endblock %}
+{% block breadcrumbs %}
+    {% if not is_popup %}
+        <ul class="grp-horizontal-list">
+            <li><a href="{% url 'admin:index' %}">{% trans "Home" %}</a></li>
+            <li><a href="{% url 'admin:app_list' app_label='archive' %}">Archive</a></li>
+            <li><a href="{% url 'admin:archive_digitizedwork_changelist'%}">Digitized Works</a></li>
+            <li>{{ page_title }}</li>
+        </ul>
+    {% endif %}
+{% endblock %}
+
+{% block content_title %}
+    <h1>{{ page_title }}</h1>
+{% endblock %}
+
+{% block content %}
+{% if results %}
+<h2>Processed {{ results|length }} HathiTrust Identifier{{ results|pluralize}}.</h2>
+<table id="result_list" cellspacing="0" class="grp-table grp-sortable">
+    <thead>
+        <tr>
+            <th scope="col">HathiTrust ID</th>
+            <th scope="col">Status</th>
+            <th scope="col">View in Admin</th>
+            <th scope="col">View on Site</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for htid, result in results.items %}
+        <tr class="grp-row {% cycle 'grp-row-even' 'grp-row-odd' %}">
+            {# link to admin record here if success/skipped #}
+            <td>{{ htid }}</td>
+            <td>{{ result }}</td>
+            {% if 'Success' in result or htid in existing_ids %}
+            <td><a href="{% url 'admin:archive_digitizedwork_change' existing_ids|dict_item:htid %}">
+                View in Admin</a></td>
+            <td><a href="{% url 'archive:detail' htid %}">
+                View on Site</a></td>
+            {% endif %}
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+{# redisplay the form to allow adding another set #}
+<div>
+<h2>Add more records?</h2>
+</div>
+{% endif %}
+
+<form method="post" style="padding-top: 2em;">{% csrf_token %}
+    <fieldset class="module grp-module">
+        {{ form.as_p }}
+         <div class="form-row grp-row grp-cells-1">
+             <div class="field-box l-2c-fluid l-d-4">
+            <input type="submit" value="Submit">
+        </div>
+    </fieldset>
+</form>
+{% endblock %}

--- a/ppa/archive/templates/archive/add_from_hathi.html
+++ b/ppa/archive/templates/archive/add_from_hathi.html
@@ -24,7 +24,7 @@
         <tr>
             <th scope="col">HathiTrust ID</th>
             <th scope="col">Status</th>
-            <th scope="col">View in Admin</th>
+            <th scope="col">Admin View</th>
             <th scope="col">View on Site</th>
         </tr>
     </thead>
@@ -35,10 +35,12 @@
             <td>{{ htid }}</td>
             <td>{{ result }}</td>
             {% if 'Success' in result or htid in existing_ids %}
-            <td><a href="{% url 'admin:archive_digitizedwork_change' existing_ids|dict_item:htid %}">
+            <td><a href="{{ admin_urls|dict_item:htid }}">
                 View in Admin</a></td>
             <td><a href="{% url 'archive:detail' htid %}">
                 View on Site</a></td>
+            {% else %}
+            <td></td><td></td>
             {% endif %}
         </tr>
         {% endfor %}

--- a/ppa/archive/tests/test_forms.py
+++ b/ppa/archive/tests/test_forms.py
@@ -5,7 +5,8 @@ from django.test import TestCase
 import pytest
 
 from ppa.archive.forms import FacetChoiceField, SearchForm, RangeWidget, \
-    RangeField, RadioSelectWithDisabled, ModelMultipleChoiceFieldWithEmpty
+    RangeField, RadioSelectWithDisabled, ModelMultipleChoiceFieldWithEmpty, \
+    AddFromHathiForm
 from ppa.archive.models import DigitizedWork, Collection
 
 
@@ -210,3 +211,15 @@ class TestModelMultipleChoiceFieldWithEmpty(TestCase):
         # non-numeric should raise validation error
         with pytest.raises(ValidationError):
             collections.clean(['1" or (1,2)=(select*from(select '])
+
+
+class TestAddFromHathiForm(TestCase):
+
+    def test_get_hathi_ids(self):
+        # list of input lines, some with whitespace and some empty
+        test_ids = ['one', ' two ', 'three', '', ' ' , ' ']
+        add_form = AddFromHathiForm({'hathi_ids': '\n'.join(test_ids)})
+        assert add_form.is_valid()
+        expected_ids = [line.strip() for line in test_ids if line.strip()]
+        assert add_form.get_hathi_ids() == expected_ids
+

--- a/ppa/archive/tests/test_models.py
+++ b/ppa/archive/tests/test_models.py
@@ -505,6 +505,12 @@ class TestDigitizedWork(TestCase):
         digwork = DigitizedWork.objects.get(source_id=digwork.source_id)
         assert digwork.page_count == 2
 
+        # should ignore non-text files
+        page_files = ['0001.txt', '00002.txt', '00001.jp2', '00002.jp2']
+        mockzip_obj.namelist.return_value = page_files
+        assert digwork.count_pages(mock_pairtree_client) == 2
+
+
         # object not found in pairtree data
         mock_pairtree_client.get_object.side_effect = \
             storage_exceptions.ObjectNotFoundException

--- a/ppa/archive/tests/test_util.py
+++ b/ppa/archive/tests/test_util.py
@@ -46,7 +46,8 @@ class TestHathiImporter(TestCase):
         mock_add_from_hathi.side_effect = hathi.HathiItemNotFound
         htimporter.add_items()
         mock_add_from_hathi.assert_called_with(
-            test_htid, htimporter.bib_api, get_data=True, log_msg_src=None)
+            test_htid, htimporter.bib_api, get_data=True,
+            log_msg_src=None, user=None)
         assert not htimporter.imported_works
         # actual error stored in results
         assert isinstance(htimporter.results[test_htid], hathi.HathiItemNotFound)
@@ -59,7 +60,7 @@ class TestHathiImporter(TestCase):
         htimporter.add_items(log_msg_src)
         mock_add_from_hathi.assert_called_with(
             test_htid, htimporter.bib_api, get_data=True,
-            log_msg_src=log_msg_src)
+            log_msg_src=log_msg_src, user=None)
         # actual error stored in results
         assert isinstance(htimporter.results[test_htid], hathi.HathiItemForbidden)
         # no partial record hanging aruond

--- a/ppa/archive/tests/test_util.py
+++ b/ppa/archive/tests/test_util.py
@@ -1,0 +1,86 @@
+from unittest.mock import patch
+
+from django.conf import settings
+from django.contrib.admin.models import LogEntry, ADDITION, CHANGE
+from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+
+from ppa.archive import hathi
+from ppa.archive.models import DigitizedWork
+from ppa.archive.util import HathiImporter
+
+
+class TestHathiImporter(TestCase):
+    fixtures = ['sample_digitized_works']
+
+    def test_filter_existing_ids(self):
+
+        digwork_ids = DigitizedWork.objects.values_list('source_id', flat=True)
+
+        # all existing - all should be flagged as existing
+        htimporter = HathiImporter(digwork_ids)
+        htimporter.filter_existing_ids()
+        # no ht ids left, all marked existing
+        assert not htimporter.htids
+        assert len(htimporter.existing_ids) == len(digwork_ids)
+        # existing_ids should be dict with source id -> pk
+        digwork = DigitizedWork.objects.first()
+        assert htimporter.existing_ids[digwork.source_id] == digwork.pk
+
+        # mix of new and existing ids
+        new_ids = ['one', 'two', 'three']
+        htimporter = HathiImporter(new_ids + list(digwork_ids))
+        htimporter.filter_existing_ids()
+        assert len(htimporter.existing_ids) == len(digwork_ids)
+        assert set(htimporter.htids) == set(new_ids)
+
+    @patch('ppa.archive.models.DigitizedWork.add_from_hathi')
+    def test_add_items(self, mock_add_from_hathi):
+
+        test_htid = 'a:123'
+        htimporter = HathiImporter([test_htid])
+        # simulate record not found
+        mock_add_from_hathi.side_effect = hathi.HathiItemNotFound
+        htimporter.add_items()
+        mock_add_from_hathi.assert_called_with(
+            test_htid, get_data=True, log_msg_src=None)
+        assert not htimporter.imported_works
+        # actual error stored in results
+        assert isinstance(htimporter.results[test_htid], hathi.HathiItemNotFound)
+        # no partial record hanging around
+        assert not DigitizedWork.objects.filter(source_id=test_htid)
+
+        # simulate permission denied
+        mock_add_from_hathi.side_effect = hathi.HathiItemForbidden
+        log_msg_src = 'from unit test'
+        htimporter.add_items(log_msg_src)
+        mock_add_from_hathi.assert_called_with(
+            test_htid, get_data=True,
+            log_msg_src=log_msg_src)
+        # actual error stored in results
+        assert isinstance(htimporter.results[test_htid], hathi.HathiItemForbidden)
+        # no partial record hanging aruond
+        assert not DigitizedWork.objects.filter(source_id=test_htid)
+
+        # simulate success
+        def fake_add_from_hathi(htid, *args, **kwargs):
+            '''fake add_from_hathi method to create
+            a new digwork and corresponding log entry'''
+            digwork = DigitizedWork.objects.create(source_id=htid,
+                                                   page_count=1337)
+            # create log entry for record creation
+            LogEntry.objects.log_action(
+                user_id=User.objects.get(username=settings.SCRIPT_USERNAME).pk,
+                content_type_id=ContentType.objects.get_for_model(digwork).pk,
+                object_id=digwork.pk,
+                object_repr=str(digwork),
+                change_message='Created %s' % log_msg_src,
+                action_flag=ADDITION)
+
+            return digwork
+
+        mock_add_from_hathi.side_effect = fake_add_from_hathi
+        htimporter.add_items(log_msg_src)
+        assert len(htimporter.imported_works) == 1
+        assert htimporter.results[test_htid] == HathiImporter.SUCCESS

--- a/ppa/archive/tests/test_views.py
+++ b/ppa/archive/tests/test_views.py
@@ -8,17 +8,19 @@ from unittest.mock import Mock, patch
 from django.contrib.auth import get_user_model
 from django.db.models.functions import Lower
 from django.template.defaultfilters import escape
-from django.test import TestCase
+from django.test import TestCase, RequestFactory
 from django.urls import reverse
 from django.utils.http import urlencode
 from django.utils.timezone import now
 import pytest
 from SolrClient.exceptions import SolrError
 
-from ppa.archive.forms import SearchForm, ModelMultipleChoiceFieldWithEmpty
+from ppa.archive.forms import SearchForm, ModelMultipleChoiceFieldWithEmpty, \
+    AddFromHathiForm
 from ppa.archive.models import DigitizedWork, Collection, NO_COLLECTION_LABEL
 from ppa.archive.solr import get_solr_connection, PagedSolrQuery
-from ppa.archive.views import DigitizedWorkCSV, DigitizedWorkListView
+from ppa.archive.views import DigitizedWorkCSV, DigitizedWorkListView, \
+    AddFromHathiView
 from ppa.archive.templatetags.ppa_tags import page_image_url, page_url
 
 
@@ -904,3 +906,98 @@ class TestDigitizedWorkListView(TestCase):
             assert ' AND id:("p1a" "p1b" "p2a" "p2b")' in solr_opts['q']
 
             assert highlights == mockpsq.return_value.get_highlighting()
+
+
+class TestAddFromHathiView(TestCase):
+
+    superuser = {
+        'username': 'super',
+        'password': 'secret',
+    }
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.add_from_hathi_url = reverse('admin:add-from-hathi')
+
+        get_user_model().objects.create_superuser(email='su@example.com',
+                                                  **self.superuser)
+
+    def test_get_context(self):
+        add_from_hathi = AddFromHathiView()
+        add_from_hathi.request = self.factory.get(self.add_from_hathi_url)
+        context = add_from_hathi.get_context_data()
+        assert context['page_title'] == AddFromHathiView.page_title
+
+    @patch('ppa.archive.views.HathiImporter')
+    def test_form_valid(self, mock_hathi_importer):
+        add_form = AddFromHathiForm({'hathi_ids': 'old\nnew'})
+        add_form.is_valid()
+
+        mock_htimporter = mock_hathi_importer.return_value
+        # set mock existing id & imported work on the mock importer
+        mock_htimporter.existing_ids = {'old': 1}
+        mock_htimporter.imported_works = [
+            Mock(source_id='new', pk=2)
+        ]
+
+        add_from_hathi = AddFromHathiView()
+        add_from_hathi.request = self.factory.post(self.add_from_hathi_url,
+            {'hathi_ids': 'old\nnew'})
+        response = add_from_hathi.form_valid(add_form)
+
+        mock_hathi_importer.assert_called_with(add_form.get_hathi_ids())
+        mock_htimporter.filter_existing_ids.assert_called_with()
+        mock_htimporter.add_items.assert_called_with(log_msg_src='via django admin')
+        mock_htimporter.index.assert_called_with()
+
+        # can't inspect response context because not called with test client
+        # sanity check result
+        assert response.status_code == 200
+
+    def test_get(self):
+        # denied to anonymous user
+        response = self.client.get(self.add_from_hathi_url)
+        # django redirects to login instead of returning 401
+        assert response.status_code == 302
+
+        self.client.login(**self.superuser)
+        response = self.client.get(self.add_from_hathi_url)
+        assert response.status_code == 200
+        self.assertTemplateUsed(response, AddFromHathiView.template_name)
+        # sanity check that form display
+        self.assertContains(response, '<form')
+        self.assertContains(response, '<textarea name="hathi_ids"')
+
+    @patch('ppa.archive.views.HathiImporter')
+    def test_post(self, mock_hathi_importer):
+        mock_htimporter = mock_hathi_importer.return_value
+        # set mock existing id & imported work on the mock importer
+        mock_htimporter.existing_ids = {'old': 1}
+        mock_htimporter.imported_works = [
+            Mock(source_id='new', pk=2)
+        ]
+        mock_htimporter.output_results.return_value = {
+            'old': mock_hathi_importer.SKIPPED,
+            'new': mock_hathi_importer.SUCCESS
+        }
+
+        self.client.login(**self.superuser)
+        response = self.client.post(self.add_from_hathi_url, {
+            'hathi_ids': 'old\nnew'
+        })
+        assert response.status_code == 200
+        self.assertContains(response, 'Processed 2 HathiTrust Identifiers')
+        # inspect context
+        assert response.context['results'] == mock_htimporter.output_results()
+        assert response.context['existing_ids'] == mock_htimporter.existing_ids
+        assert isinstance(response.context['form'], AddFromHathiForm)
+        assert response.context['page_title'] == AddFromHathiView.page_title
+        assert 'admin_urls' in response.context
+        assert response.context['admin_urls']['old'] == \
+            reverse('admin:archive_digitizedwork_change', args=[1])
+        assert response.context['admin_urls']['new'] == \
+            reverse('admin:archive_digitizedwork_change', args=[2])
+
+        # should redisplay the form
+        self.assertContains(response, '<form')
+        self.assertContains(response, '<textarea name="hathi_ids"')

--- a/ppa/archive/tests/test_views.py
+++ b/ppa/archive/tests/test_views.py
@@ -919,8 +919,9 @@ class TestAddFromHathiView(TestCase):
         self.factory = RequestFactory()
         self.add_from_hathi_url = reverse('admin:add-from-hathi')
 
-        get_user_model().objects.create_superuser(email='su@example.com',
-                                                  **self.superuser)
+        self.user = get_user_model().objects\
+            .create_superuser(email='su@example.com',
+                              **self.superuser)
 
     def test_get_context(self):
         add_from_hathi = AddFromHathiView()
@@ -943,11 +944,13 @@ class TestAddFromHathiView(TestCase):
         add_from_hathi = AddFromHathiView()
         add_from_hathi.request = self.factory.post(self.add_from_hathi_url,
             {'hathi_ids': 'old\nnew'})
+        add_from_hathi.request.user = self.user
         response = add_from_hathi.form_valid(add_form)
 
         mock_hathi_importer.assert_called_with(add_form.get_hathi_ids())
         mock_htimporter.filter_existing_ids.assert_called_with()
-        mock_htimporter.add_items.assert_called_with(log_msg_src='via django admin')
+        mock_htimporter.add_items.assert_called_with(log_msg_src='via django admin',
+                                                     user=self.user)
         mock_htimporter.index.assert_called_with()
 
         # can't inspect response context because not called with test client

--- a/ppa/archive/util.py
+++ b/ppa/archive/util.py
@@ -1,0 +1,125 @@
+'''
+
+Utility code related to :mod:`ppa.archives`
+
+'''
+
+from collections import OrderedDict
+from json.decoder import JSONDecodeError
+
+from ppa.archive.hathi import HathiItemNotFound, HathiItemForbidden
+from ppa.archive.models import DigitizedWork
+from ppa.archive.signals import IndexableSignalHandler
+from ppa.archive.solr import get_solr_connection
+
+
+class HathiImporter:
+    '''Logic for creating new :class:`~ppa.archive.models.DigitizedWork`
+    records from HathiTrust. For use in views and manage commands.'''
+
+    existing_ids = None
+
+    #: status - successfully imported record
+    SUCCESS = 1
+    #: status - skipped because already in the database
+    SKIPPED = 2
+
+    #: human-readable message to display for result status
+    status_message = {
+        SUCCESS: 'Success',
+        SKIPPED: 'Skipped; already in the database',
+        HathiItemNotFound: 'Error loading record; check that id is valid.',
+        HathiItemForbidden: 'Permission denied to download data.',
+        # only saw this one on day, but this was what it was
+        JSONDecodeError: 'HathiTrust catalog temporarily unavailable.'
+    }
+
+    def __init__(self, htids):
+        self.imported_works = []
+        self.results = {}
+        self.htids = htids
+        # not calling filter_existing_ids here because it is
+        # probably not desirable behavior for current hathi_import script
+
+    def filter_existing_ids(self):
+        '''Check for any ids that are in the database so they can
+        be skipped for import.  Populates :attr:`existing_ids`
+        with an :class:`~collections.OrderedDict` of htid -> id for
+        ids already in the database and filters :attr:`htids`.
+
+        :param htids: list of HathiTrust Identifiers (correspending to
+            :attr:`~ppa.archive.models.DigitizedWork.source_id`)
+        :returns: tuple of:
+            - list of htids not present in the database
+            - dictionary of
+        '''
+        # query for digitized work with these ids and return
+        # source id, db id and generate an ordered dict
+        self.existing_ids = OrderedDict(
+            DigitizedWork.objects.filter(source_id__in=self.htids) \
+                                 .values_list('source_id', 'id'))
+
+        # create initial results dict, marking any skipped ids
+        self.results = OrderedDict(
+            (htid, self.SKIPPED)
+            for htid in self.existing_ids.keys())
+
+        # filter to ids that are not already present in the database
+        self.htids = set(self.htids) - set(self.existing_ids.keys())
+
+    def add_items(self, log_msg_src=None):
+        '''Add new items from HathiTrust.
+
+        :params log_msg_src: optional source of change to be included in
+            log entry message
+
+        '''
+        # disconnect indexing signal handler before adding new content
+        IndexableSignalHandler.disconnect()
+
+        for htid in self.htids:
+            try:
+                digwork = DigitizedWork.add_from_hathi(
+                    htid, get_data=True,
+                    log_msg_src=log_msg_src)
+                # TODO pass in current user
+                if digwork:
+                    self.imported_works.append(digwork)
+
+                self.results[htid] = self.SUCCESS
+            except (HathiItemNotFound, JSONDecodeError,
+                    HathiItemForbidden) as err:
+                # json decode error occurred 3/26/2019 - catalog was broken
+                # and gave a 200 Ok response with PHP error content
+                # hopefully temporary, but could occur again...
+
+                # store the actual error as the results, so that
+                # downstream code can report as desired
+                self.results[htid] = err
+
+                # remove the partial record if one was created
+                # (i.e. if metadata succeeded but data failed)
+                DigitizedWork.objects.filter(source_id=htid).delete()
+
+        # reconnect indexing signal handler
+        IndexableSignalHandler.connect()
+
+    def index(self):
+        '''Index newly imported content, both metadata and full text.'''
+        if self.imported_works:
+            DigitizedWork.index_items(self.imported_works)
+            for work in self.imported_works:
+                # index page index data in chunks (returns a generator)
+                DigitizedWork.index_items(work.page_index_data())
+
+            solr, solr_collection = get_solr_connection()
+            solr.commit(solr_collection, openSearcher=True)
+
+    def output_results(self):
+        '''Provide human-readable report of results for each
+        id that was processed.'''
+        return OrderedDict([
+            (htid, self.status_message[status]) if status in self.status_message
+            else self.status_message[status.__class__]
+            for htid, status in self.results.items()
+        ])

--- a/ppa/archive/util.py
+++ b/ppa/archive/util.py
@@ -31,7 +31,7 @@ class HathiImporter:
         hathi.HathiItemNotFound: 'Error loading record; check that id is valid.',
         hathi.HathiItemForbidden: 'Permission denied to download data.',
         # only saw this one on day, but this was what it was
-        JSONDecodeError: 'HathiTrust catalog temporarily unavailable.'
+        JSONDecodeError: 'HathiTrust catalog temporarily unavailable (malformed response).'
     }
 
     def __init__(self, htids):
@@ -53,9 +53,6 @@ class HathiImporter:
 
         :param htids: list of HathiTrust Identifiers (correspending to
             :attr:`~ppa.archive.models.DigitizedWork.source_id`)
-        :returns: tuple of:
-            - list of htids not present in the database
-            - dictionary of
         '''
         # query for digitized work with these ids and return
         # source id, db id and generate an ordered dict

--- a/ppa/archive/util.py
+++ b/ppa/archive/util.py
@@ -71,7 +71,7 @@ class HathiImporter:
         # filter to ids that are not already present in the database
         self.htids = set(self.htids) - set(self.existing_ids.keys())
 
-    def add_items(self, log_msg_src=None):
+    def add_items(self, log_msg_src=None, user=None):
         '''Add new items from HathiTrust.
 
         :params log_msg_src: optional source of change to be included in
@@ -85,8 +85,7 @@ class HathiImporter:
             try:
                 digwork = DigitizedWork.add_from_hathi(
                     htid, self.bib_api, get_data=True,
-                    log_msg_src=log_msg_src)
-                # TODO pass in current user
+                    log_msg_src=log_msg_src, user=user)
                 if digwork:
                     self.imported_works.append(digwork)
 

--- a/ppa/archive/views.py
+++ b/ppa/archive/views.py
@@ -594,8 +594,9 @@ class AddFromHathiView(FormView):
 
         htimporter = HathiImporter(htids)
         htimporter.filter_existing_ids()
-        # IndexableSignalHandler.disconnect()
-        htimporter.add_items(log_msg_src='via django admin')
+        # add items, and create log entries associated with current user
+        htimporter.add_items(log_msg_src='via django admin',
+                             user=self.request.user)
         htimporter.index()
 
         # generate lookup for admin urls keyed on source id to simplify

--- a/sphinx-docs/codedocs.rst
+++ b/sphinx-docs/codedocs.rst
@@ -40,6 +40,11 @@ Hathi
 .. automodule:: ppa.archive.hathi
     :members:
 
+Util
+^^^^^
+.. automodule:: ppa.archive.util
+    :members:
+
 
 Pages
 -----


### PR DESCRIPTION
- refactors logic from `hathi_add` script into new `ppa.archive.util.HathiImporter` for reuse
- reports what was done in human-readable fashion, with links to admin and public views for existing ids that were skipped or newly created records
- new `AddFromHathi` form and view, bound to admin urls for `DigitizedWork`
- use current logged in user for log entries created to document the record creation