### PR TITLE
Custom wagtail embed finder for glitch (WIP)

### DIFF
--- a/ppa/pages/embed_finders.py
+++ b/ppa/pages/embed_finders.py
@@ -1,0 +1,48 @@
+from urllib.parse import urljoin
+
+import requests
+from wagtail.embeds.finders.base import EmbedFinder
+
+
+class GlitchEmbedFinder(EmbedFinder):
+    def __init__(self, **options):
+        pass
+
+    def accept(self, url):
+        """
+        Returns True if this finder knows how to fetch an embed for the URL.
+
+        This should not have any side effects (no requests to external servers)
+        """
+        if '.glitch.me' in url:
+            return True
+
+        return False
+
+    def find_embed(self, url, max_width=None):
+        """
+        Takes a URL and max width and returns a dictionary of information about
+        the content to be used for embedding it on the site.
+
+        This is the part that may make requests to external APIs.
+        """
+        # TODO: Perform the request
+
+        response = requests.get(urljoin(url, 'embed.json'))
+        if response.status_code == requests.codes.ok:
+            embed_info = response.json()
+
+            response = requests.get(url)
+            embed_info['html'] = response.content
+            return embed_info
+
+        # return {
+        #     'title': "Title of the content",
+        #     'author_name': "Author name",
+        #     'provider_name': "Provider name (eg. YouTube, Vimeo, etc)",
+        #     'type': "Either 'photo', 'video', 'link' or 'rich'",
+        #     'thumbnail_url': "URL to thumbnail image",
+        #     'width': width_in_pixels,
+        #     'height': height_in_pixels,
+        #     'html': "<h2>The Embed HTML</h2>",
+        # }

--- a/ppa/pages/models.py
+++ b/ppa/pages/models.py
@@ -4,12 +4,14 @@ from django.template.defaultfilters import truncatechars_html, striptags
 from wagtail.core import blocks
 from wagtail.core.models import Page
 from wagtail.core.fields import RichTextField, StreamField
+
 from wagtail.admin.edit_handlers import FieldPanel, PageChooserPanel, \
     StreamFieldPanel
 from wagtail.images.blocks import ImageChooserBlock
 from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.images.models import Image
 from wagtail.documents.blocks import DocumentChooserBlock
+from wagtail.embeds.blocks import EmbedBlock
 from wagtail.snippets.blocks import SnippetChooserBlock
 from wagtail.snippets.models import register_snippet
 
@@ -135,12 +137,32 @@ class ImageWithCaption(blocks.StructBlock):
         ('full', 'Full Width'),
         ('left', 'Floated Left'),
         ('right', 'Floated Right'),
-        ], help_text='Controls how other content flows around the image. Note \
-            that this will only take effect on larger screens. Float consecutive \
-            images in opposite directions for side-by-side display.')
+    ], help_text='Controls how other content flows around the image. Note \
+        that this will only take effect on larger screens. Float consecutive \
+        images in opposite directions for side-by-side display.')
 
     class Meta:
         icon = 'image'
+
+
+class ScriptBlock(blocks.StructBlock):
+    ''':class:`~wagtail.core.blocks.StructBlock` for an image with
+    a formatted caption, so caption can be context-specific. Also allows images
+    to be floated right, left, or take up the width of the page.'''
+    image = ImageChooserBlock()
+    caption = blocks.RichTextBlock(required=False,
+                                   features=['bold', 'italic', 'link'])
+    style = blocks.ChoiceBlock(required=True, default='full', choices=[
+        ('full', 'Full Width'),
+        ('left', 'Floated Left'),
+        ('right', 'Floated Right'),
+    ], help_text='Controls how other content flows around the image. Note \
+        that this will only take effect on larger screens. Float consecutive \
+        images in opposite directions for side-by-side display.')
+
+    class Meta:
+        icon = 'image'
+
 
 
 class BodyContentBlock(blocks.StreamBlock):
@@ -156,6 +178,7 @@ class BodyContentBlock(blocks.StreamBlock):
         classname='footnotes'
     )
     document = DocumentChooserBlock()
+    embed = EmbedBlock()
 
 
 class PagePreviewDescriptionMixin(models.Model):

--- a/ppa/pages/tests/test_embed_finders.py
+++ b/ppa/pages/tests/test_embed_finders.py
@@ -1,0 +1,61 @@
+from unittest.mock import Mock, patch
+
+import requests
+import pytest
+from wagtail.embeds.exceptions import EmbedException
+
+from ppa.pages.embed_finders import GlitchEmbedFinder
+
+
+class TestGlitchEmbedFinder:
+
+    def test_accept(self):
+        assert GlitchEmbedFinder().accept('foobar.glitch.me')
+        assert not GlitchEmbedFinder().accept('youtube.com/foo')
+
+    test_html = '''<html>
+    <head>
+        <link rel="stylesheet" type="text/css" href="mystyles.css"/>
+    </head>
+    <body>
+        <script src="myscript.js"></script>
+    </body>
+    </html>
+    '''
+
+    @patch('ppa.pages.embed_finders.requests')
+    def test_find_embed(self, mockrequests):
+        # patch in actual request status codes
+        mockrequests.codes = requests.codes
+        glitcher = GlitchEmbedFinder()
+
+        # embed response fails
+        mockrequests.get.return_value.status_code = 404
+        with pytest.raises(EmbedException):
+            glitcher.find_embed('http://test.glitch.me')
+        mockrequests.get.assert_called_with('http://test.glitch.me/embed.json')
+
+        # json request succeeeds but main url does not
+        mockrequests.get.side_effect = (Mock(status_code=200),
+                                        Mock(status_code=500))
+        with pytest.raises(EmbedException):
+            glitcher.find_embed('http://test.glitch.me')
+
+        mockrequests.get.side_effect = None
+        mockrequests.get.return_value.status_code = 200
+        mock_embed = {
+            'title': 'test glitch',
+            'author_name': 'me'
+        }
+        mockrequests.get.return_value.json.return_value = mock_embed
+        mockrequests.get.return_value.content = self.test_html
+        embed_info = glitcher.find_embed('http://test.glitch.me')
+        mockrequests.get.assert_called_with('http://test.glitch.me')
+        # embed info from json
+        assert embed_info['title'] == mock_embed['title']
+        assert embed_info['author_name'] == mock_embed['author_name']
+        # html from response content
+        assert embed_info['html'].startswith('<html>')
+        # relative links made absolute
+        assert 'href="http://test.glitch.me/mystyles.css' in embed_info['html']
+        assert 'src="http://test.glitch.me/myscript.js' in embed_info['html']

--- a/ppa/pages/tests/test_embed_finders.py
+++ b/ppa/pages/tests/test_embed_finders.py
@@ -1,3 +1,4 @@
+from json import JSONDecodeError
 from unittest.mock import Mock, patch
 
 import requests
@@ -40,8 +41,15 @@ class TestGlitchEmbedFinder:
                                         Mock(status_code=500))
         with pytest.raises(EmbedException):
             glitcher.find_embed('http://test.glitch.me')
-
         mockrequests.get.side_effect = None
+
+        # json decode error
+        with pytest.raises(EmbedException):
+            mockrequests.get.return_value.json.side_effect = JSONDecodeError
+            glitcher.find_embed('http://test.glitch.me')
+
+        mockrequests.get.return_value.json.side_effect = None
+
         mockrequests.get.return_value.status_code = 200
         mock_embed = {
             'title': 'test glitch',

--- a/ppa/settings.py
+++ b/ppa/settings.py
@@ -312,7 +312,7 @@ if os.path.exists(f):
 WEBPACK_LOADER = {
     'DEFAULT': {
         'CACHE': not DEBUG,
-        'BUNDLE_DIR_NAME': 'bundles/', # must end with slash
+        'BUNDLE_DIR_NAME': 'bundles/',  # must end with slash
         'STATS_FILE': os.path.join(BASE_DIR, 'webpack-stats.json'),
         'POLL_INTERVAL': 0.1,
         'TIMEOUT': None,

--- a/ppa/settings.py
+++ b/ppa/settings.py
@@ -259,13 +259,14 @@ CSP_DEFAULT_SRC = "'none'"
 
 # allow loading js locally, from a cdn, and from google (for analytics)
 CSP_SCRIPT_SRC = ("'self'", 'https://cdnjs.cloudflare.com',
-                  'https://www.googletagmanager.com')
+                  'https://www.googletagmanager.com', "*.glitch.me")
 
 # allow loading fonts locally and from google (via data: url)
 CSP_FONT_SRC = ("'self'", 'https://fonts.gstatic.com data:')
 
 # allow loading css locally and from google (for fonts)
-CSP_STYLE_SRC = ("'self'", 'https://fonts.googleapis.com')
+CSP_STYLE_SRC = ("'self'", 'https://fonts.googleapis.com',
+                 '*.glitch.me')
 
 # allow loading local images, hathi page images, google tracking pixel
 CSP_IMG_SRC = ("'self'", 'https://babel.hathitrust.org',
@@ -278,7 +279,7 @@ CSP_EXCLUDE_URL_PREFIXES = ('/admin', '/cms')
 CSP_INCLUDE_NONCE_IN = ('script-src',)
 
 # allow local scripts to connect to source (i.e. searchLoading)
-CSP_CONNECT_SRC = ("'self'", "https://www.google-analytics.com")
+CSP_CONNECT_SRC = ("'self'", "https://www.google-analytics.com", "*.glitch.me")
 
 # load a manifest file
 CSP_MANIFEST_SRC = "'self'"

--- a/ppa/settings.py
+++ b/ppa/settings.py
@@ -86,11 +86,11 @@ INSTALLED_APPS = [
     'webpack_loader',
     # 'wagtail.contrib.forms',
     'wagtail.contrib.redirects',
-    # 'wagtail.embeds',
     'wagtail.sites',
     'wagtail.users',
     'wagtail.snippets',
     'wagtail.documents',
+    'wagtail.embeds',
     'wagtail.images',
     # 'wagtail.search',
     'wagtail.admin',
@@ -223,6 +223,15 @@ MEDIA_ROOT = os.path.join(BASE_DIR, *MEDIA_URL.strip("/").split("/"))
 SITE_ID = 1
 
 WAGTAIL_SITE_NAME = 'Princeton Prosody Archive'
+
+WAGTAILEMBEDS_FINDERS = [
+    {
+        'class': 'wagtail.embeds.finders.oembed'
+    },
+    {
+        'class': 'ppa.pages.embed_finders.GlitchEmbedFinder'
+    },
+]
 
 GRAPPELLI_ADMIN_TITLE = 'Princeton Prosody Archive Admin'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,6 @@ django-csp
 django-webpack-loader
 requests_oauthlib
 wand
-
+beautifulsoup4
 # only needed for the 'generate_corpus' manage command
 gensim

--- a/sphinx-docs/codedocs.rst
+++ b/sphinx-docs/codedocs.rst
@@ -57,6 +57,11 @@ Models
 .. automodule:: ppa.pages.models
     :members:
 
+Embed Finders
+^^^^^^^^^^^^^
+.. automodule:: ppa.pages.embed_finders
+    :members:
+
 
 Editorial
 ---------


### PR DESCRIPTION
Have a preliminary approach for embedding glitch content in wagtail, haven't written tests or much in the way of documentation. Hoping for a quick review to check that the approach seems reasonable.

You can test it by embedding this url: https://ppa-collection-stripes2.glitch.me/ 
I customized styles to match PPA mobile/tablet/desktop so it should embed nicely; not sure how/if to generalize that.

You can see the embed.json in the glitch project here: https://glitch.com/edit/#!/ppa-collection-stripes2?path=embed.json:1:0

It should also work to embed this one, although I haven't customized the styles for tablet/mobile yet. https://ppa-collections-treemap.glitch.me