### PR TITLE
Use solr KeywordRepeatFilterFactory instead of unstemmed field copies

### DIFF
--- a/ppa/archive/solr.py
+++ b/ppa/archive/solr.py
@@ -29,6 +29,9 @@ class UnicodeTextAnalyzer(schema.SolrAnalyzer):
             {"class": "solr.KeywordRepeatFilterFactory"},
             {"class": "solr.PorterStemFilterFactory"},
             {"class": "solr.ICUFoldingFilterFactory"},
+            # remove duplicates after repeat since some stemmed and unstemmed
+            # tokens may match
+            {"class": "solr.RemoveDuplicatesTokenFilterFactory"}
         ]
 
 

--- a/ppa/archive/solr.py
+++ b/ppa/archive/solr.py
@@ -13,8 +13,9 @@ class SolrTextField(schema.SolrTypedField):
 
 class UnicodeTextAnalyzer(schema.SolrAnalyzer):
         '''Solr text field analyzer with unicode folding. Includes all standard
-        text field analyzers (stopword filters, lower case, possessive, keyword
-        marker, porter stemming) and adds ICU folding filter factory.
+        text field analyzers (stopword filters, lower case, possessive,
+        porter stemming) and adds ICU folding filter factory.
+        Uses a keyword repeat before stemming to preserve original words.
         '''
         tokenizer = 'solr.StandardTokenizerFactory'
         filters = [
@@ -22,26 +23,13 @@ class UnicodeTextAnalyzer(schema.SolrAnalyzer):
              "words": "lang/stopwords_en.txt"},
             {"class": "solr.LowerCaseFilterFactory"},
             {"class": "solr.EnglishPossessiveFilterFactory"},
-            {"class": "solr.KeywordMarkerFilterFactory"},
+            # keyword protection not actually in use
+            # (protected list not not modified)
+            # {"class": "solr.KeywordMarkerFilterFactory"},
+            {"class": "solr.KeywordRepeatFilterFactory"},
             {"class": "solr.PorterStemFilterFactory"},
             {"class": "solr.ICUFoldingFilterFactory"},
         ]
-
-
-class UnstemmedTextAnalyzer(schema.SolrAnalyzer):
-    '''Solr text field analyzer without unstemming. Exactly the same as
-    :class:`UnicodeTextAnalyzer` except without PorterStemFilterFactory.
-    Used as a secondary search field, so exact matches can be prioritized
-    over stemmed matches.'''
-    tokenizer = 'solr.StandardTokenizerFactory'
-    filters = [
-        {"class": "solr.StopFilterFactory", "ignoreCase": True,
-         "words": "lang/stopwords_en.txt"},
-        {"class": "solr.LowerCaseFilterFactory"},
-        {"class": "solr.EnglishPossessiveFilterFactory"},
-        {"class": "solr.KeywordMarkerFilterFactory"},
-        {"class": "solr.ICUFoldingFilterFactory"},
-    ]
 
 
 class TextKeywordTextAnalyzer(schema.SolrAnalyzer):
@@ -64,8 +52,6 @@ class SolrSchema(schema.SolrSchema):
     # declare custom field types
     text_en = schema.SolrFieldType(
         'solr.TextField', analyzer=UnicodeTextAnalyzer)
-    text_nostem = schema.SolrFieldType(
-        'solr.TextField', analyzer=UnstemmedTextAnalyzer)
     string_i = schema.SolrFieldType(
         'solr.TextField', analyzer=TextKeywordTextAnalyzer,
         sortMissingLast=True)
@@ -96,21 +82,13 @@ class SolrSchema(schema.SolrSchema):
     author_exact = schema.SolrStringField()
     collections_exact = schema.SolrStringField(multivalued=True)
 
-    # fields without stemming for search boosting
-    title_nostem = schema.SolrField('text_nostem', stored=False)
-    subtitle_nostem = schema.SolrField('text_nostem', stored=False)
-    content_nostem = schema.SolrField('text_nostem', stored=True)
-
     # have solr automatically track last index time
     last_modified = schema.SolrField('date', default='NOW')
 
-    #: define copy fields for facets and unstemmed variants
+    #: define copy fields for facet/sort
     copy_fields = {
         'author': 'author_exact',
         'collections': 'collections_exact',
-        'title': 'title_nostem',
-        'subtitle': 'subtitle_nostem',
-        'content': 'content_nostem',
     }
 
 
@@ -210,8 +188,7 @@ class ArchiveSearchQuerySet(SolrQuerySet):
         qs_copy = qs_copy.search(combined_query) \
             .filter('{!collapse field=source_id sort="order asc"}') \
             .raw_query_parameters(
-                content_query='content:(%(kw)s) OR content_nostem:(%(kw)s)' %
-                              {'kw': self.keyword_query},
+                content_query='content:(%s)' % self.keyword_query,
                 keyword_query=self.keyword_query,
                 expand='true', work_query=work_query, **{'expand.rows': 2})
 

--- a/ppa/archive/templates/archive/snippets/page_preview.html
+++ b/ppa/archive/templates/archive/snippets/page_preview.html
@@ -31,15 +31,8 @@ Expected context variables:
               p. {{ page.label }}
             </a>
           </p>
-        {# display unstemmed highlights by preference, since in some cases it includes matches not in content #}
-        {# NOTE: might be possible to rely on content_nostem only #}
-        {% for snippet in highlights.content_nostem %}
+        {% for snippet in highlights.content %}
         <p class="snippet">{{ snippet|solr_highlight }}</p>
         {% endfor %}
-        {% if not highlights.content_nostem %}
-          {% for snippet in highlights.content %}
-          <p class="snippet">{{ snippet|solr_highlight }}</p>
-          {% endfor %}
-        {% endif %}
     </div>
 </div>

--- a/ppa/archive/views.py
+++ b/ppa/archive/views.py
@@ -280,7 +280,7 @@ class DigitizedWorkDetailView(AjaxTemplateMixin, SolrLastModifiedMixin,
             # only return fields needed for page result display,
             # configure highlighting on page text content
             solr_pageq = SolrQuerySet() \
-                .search(content='(%s)' % query, content_nostem=('%s)' % query)) \
+                .search(content='(%s)' % query) \
                 .filter(source_id='(%s)' % digwork.source_id,
                         item_type='page') \
                 .only('id', 'source_id', 'order', 'title', 'label') \

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -753,8 +753,6 @@
       <str name="defType">edismax</str>
       <!-- <str name="df">text</str> -->
       <str name="keyword_qf">
-          title_nostem^40
-          subtitle_nostem^30
           title^20
           subtitle^15
           author^80
@@ -764,31 +762,23 @@
           pub_place
           publisher
           source_id^10
-          content_nostem^60
           content
       </str>
       <str name="keyword_pf">
-          title_nostem^70
-          subtitle_nostem^60
           title^50
           subtitle^35
           author^100
           notes^50
-          content_nostem^60
           content
           pub_place
           publisher
       </str>
       <str name="search_title_qf">
-        title_nostem^100
         title^80
-        subtitle_nostem^50
         subtitle^25
       </str>
       <str name="search_title_pf">
-        title_nostem^100
         title^80
-        subtitle_nostem^50
         subtitle^25
       </str>
     </lst>


### PR DESCRIPTION
Simpler solution for unstemmed search — instead of creating duplicate fields with and without stemming, we use Solr's keyword repeat filter to duplicate the unstemmed words before stemming is applied.

See https://lucene.apache.org/solr/guide/6_6/language-analysis.html#LanguageAnalysis-KeywordRepeatFilterFactory 