### PR TITLE
chore/page indexing multiproc

### DIFF
--- a/DEVELOPERNOTES.rst
+++ b/DEVELOPERNOTES.rst
@@ -1,10 +1,23 @@
 Troubleshooting
--------------
+===============
 
-Trouble launching Solr? Try configuring Java to version 8. Later versions of 
+Setup
+-----
+
+Trouble launching Solr? Try configuring Java to version 8. Later versions of
 Java will cause Solr 6 to time out.
 
-Solr changes not reflected in search results? ``solrconfig.xml`` must be 
+Solr changes not reflected in search results? ``solrconfig.xml`` must be
 updated in Solr's main directory: ``solr/server/solr/[CORE]/conf/solrconfig.xml``
 
 We currently do not support Python 3.7 or Solr 7 and above.
+
+Indexing with multiprocessing
+-----------------------------
+
+To run the multiprocessing page index script (`index_pages`) on MacOS versions past High Sierra, you must disable a security feature that restricts multithreading.
+Set this environment variable to override it: `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`
+
+For more details, see `stack overflow <https://stackoverflow.com/questions/50168647/multiprocessing-causes-python-to-crash-and-gives-an-error-may-have-been-in-progr/52230415#52230415>`_.
+
+

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ppa-django
-==============
+==========
 
 .. sphinx-start-marker-do-not-remove
 

--- a/ppa/archive/management/commands/index_pages.py
+++ b/ppa/archive/management/commands/index_pages.py
@@ -105,5 +105,5 @@ class Command(BaseCommand):
             for item_type, total in facets.facet_fields.item_type.items():
                 item_totals.append('%d %s%s' % (
                     total, item_type, '' if total == 1 else 's'))
-            print('\nItems in Solr by item type: %s' %
-                  (', '.join(item_totals)))
+            self.stdout.write('\nItems in Solr by item type: %s' %
+                              (', '.join(item_totals)))

--- a/ppa/archive/management/commands/index_pages.py
+++ b/ppa/archive/management/commands/index_pages.py
@@ -73,7 +73,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--cpus', default=cpu_count(),
+            '--cpus', default=cpu_count(), type=int,
             help='Number of CPUs to use (cpu_count by default: %(default)s)')
 
     def handle(self, *args, **kwargs):

--- a/ppa/archive/management/commands/index_pages.py
+++ b/ppa/archive/management/commands/index_pages.py
@@ -71,6 +71,10 @@ class Command(BaseCommand):
     '''Index page data in Solr (multiprocessor implementation)'''
     help = __doc__
 
+    #: normal verbosity level
+    v_normal = 1
+    verbosity = v_normal
+
     def add_arguments(self, parser):
         parser.add_argument(
             '-p', '--processes', default=cpu_count(), type=int,
@@ -78,9 +82,12 @@ class Command(BaseCommand):
                  '(cpu_count by default: %(default)s)')
 
     def handle(self, *args, **kwargs):
+        self.verbosity = kwargs.get('verbosity', self.v_normal)
+        if self.verbosity >= self.v_normal:
+            self.stdout.write('Indexing with %d processes' %
+                              max(2, kwargs['processes']))
         work_q = Queue()
         page_data_q = Queue()
-
         # populate the work queue with digitized works that have
         # page content to be indexed
         for digwork in DigitizedWork.items_to_index():

--- a/ppa/archive/management/commands/index_pages.py
+++ b/ppa/archive/management/commands/index_pages.py
@@ -20,7 +20,7 @@ def page_index_data(work_q, page_data_q):
     while True:
         try:
             digwork = work_q.get(True, 1)
-            # convert to the generator to a list
+            # convert the generator to a list
             # — might be nice to chunk, but most books are small
             # enough it doesn't matter that much
             page_data_q.put(list(Page.page_index_data(digwork)))

--- a/ppa/archive/management/commands/index_pages.py
+++ b/ppa/archive/management/commands/index_pages.py
@@ -1,0 +1,97 @@
+'''
+Custom multiprocessing Solr index script for page index data.
+'''
+
+import queue
+from multiprocessing import Process, Queue, cpu_count
+from time import sleep
+
+from django.core.management.base import BaseCommand
+from parasolr.django import SolrClient, SolrQuerySet
+import progressbar
+
+from ppa.archive.models import DigitizedWork, Page
+
+
+def page_index_data(work_q, page_data_q):
+    '''Function to generate page index data and add it to
+    a queue. Takes a queue with digitized works to generate pages
+    for and a queue where page data will be added.'''
+    while True:
+        try:
+            digwork = work_q.get(True, 1)
+            # convert to the generator to a list
+            # — might be nice to chunk, but most books are small
+            # enough it doesn't matter that much
+            page_data_q.put(list(Page.page_index_data(digwork)))
+        except queue.Empty:
+            # worker is done when the work queue is empty
+            return
+
+
+def process_index_queue(index_data_q, total_to_index, work_q):
+    '''Function to send index data to Solr. Takes a
+    queue to poll for index data, a total of the items
+    to be indexed (for use with progess bar), and a work queue
+    as a way of checking that all indexing is complete.'''
+
+    solr = SolrClient()
+    progbar = progressbar.ProgressBar(redirect_stdout=True,
+                                      max_value=total_to_index)
+    count = 0
+    while True:
+        try:
+            # get data from the queue and put it into Solr
+            # block with a timeout
+            index_data = index_data_q.get(timeout=5)
+            solr.update.index(index_data)
+            # increase count based on the number of items in the list
+            count += len(index_data)
+            progbar.update(count)
+        except queue.Empty:
+            # only end if work q is also empty; otherwise, loop again
+            # indexer has just gotten ahead of page index data
+            if work_q.empty():
+                progbar.finish()
+
+                # print a summary of solr totals by item type
+                facets = SolrQuerySet().all().facet('item_type').get_facets()
+                item_totals = []
+                for item_type, total in facets.facet_fields.item_type.items():
+                    item_totals.append('%d %s%s' % (
+                        total, item_type, '' if total == 1 else 's'))
+                print('\nItems in Solr by item type: %s' %
+                      (', '.join(item_totals)))
+
+                # finish indexing process
+                return
+
+
+class Command(BaseCommand):
+    '''Index page data in Solr (multiprocessor implementation)'''
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--cpus', default=cpu_count(),
+            help='Number of CPUs to use (cpu_count by default: %(default)s)')
+
+    def handle(self, *args, **kwargs):
+        work_q = Queue()
+        page_data_q = Queue()
+
+        # populate the work queue with digitized works that have
+        # page content to be indexed
+        for digwork in DigitizedWork.items_to_index():
+            work_q.put(digwork)
+
+        # start multiple processes to populate the page index data queue
+        for i in range(kwargs['cpus'] - 1):
+            Process(
+                target=page_index_data, args=(work_q, page_data_q)).start()
+
+        # give the page data a head start, since indexing is faster
+        sleep(10)
+        # start a single indexing process
+        Process(target=process_index_queue,
+                args=(page_data_q, Page.total_to_index(), work_q)).start()

--- a/ppa/archive/management/commands/index_pages.py
+++ b/ppa/archive/management/commands/index_pages.py
@@ -73,8 +73,9 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--cpus', default=cpu_count(), type=int,
-            help='Number of CPUs to use (cpu_count by default: %(default)s)')
+            '-p', '--processes', default=cpu_count(), type=int,
+            help='Number of processes to use ' +
+                 '(cpu_count by default: %(default)s)')
 
     def handle(self, *args, **kwargs):
         work_q = Queue()
@@ -86,7 +87,8 @@ class Command(BaseCommand):
             work_q.put(digwork)
 
         # start multiple processes to populate the page index data queue
-        for i in range(kwargs['cpus'] - 1):
+        # (need at least 1 page data process, no matter what was specified)
+        for i in range(max(1, kwargs['processes'] - 1)):
             Process(
                 target=page_index_data, args=(work_q, page_data_q)).start()
 

--- a/ppa/archive/tests/test_commands.py
+++ b/ppa/archive/tests/test_commands.py
@@ -369,7 +369,7 @@ class TestIndexPagesCommand(TestCase):
             call_command('index_pages', stdout=stdout)
 
             # Process should be called at least twice
-            assert mock_process.call_count > 2
+            assert mock_process.call_count >= 2
             # could inspect to confirm called correctly, but probably
             # requires
 

--- a/ppa/archive/tests/test_commands.py
+++ b/ppa/archive/tests/test_commands.py
@@ -1,13 +1,15 @@
-from collections import defaultdict
-from io import StringIO
 import json
 import os
+import queue
 import tempfile
 import types
-from unittest.mock import patch, Mock
+from collections import defaultdict
+from io import StringIO
+from multiprocessing import cpu_count
+from unittest.mock import Mock, patch
 
 from django.conf import settings
-from django.contrib.admin.models import LogEntry, ADDITION, CHANGE
+from django.contrib.admin.models import ADDITION, CHANGE, LogEntry
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core.management import call_command
@@ -16,9 +18,9 @@ from django.test import TestCase, override_settings
 import pytest
 
 from ppa.archive import hathi
-from ppa.archive.models import DigitizedWork
-from ppa.archive.management.commands import hathi_import, hathi_add
-# from ppa.archive.management.commands import hathi_import, index, hathi_add
+from ppa.archive.models import DigitizedWork, Page
+from ppa.archive.management.commands import hathi_add, hathi_import, \
+    index_pages
 from ppa.archive.util import HathiImporter
 
 
@@ -199,168 +201,6 @@ class TestHathiImportCommand(TestCase):
             mockprogbar.ProgressBar.assert_called_with(redirect_stdout=True,
                                                        max_value=len(mock_htids))
 
-# disabled until index script is removed or refactored
-# class TestIndexCommand(TestCase):
-#     fixtures = ['sample_digitized_works']
-
-#     @patch('ppa.archive.management.commands.index.Indexable')
-#     def test_index(self, mockindexable):
-#         # index data into solr and catch  an error
-#         cmd = index.Command()
-#         cmd.solr = Mock()
-#         cmd.solr_collection = 'test'
-
-#         test_index_data = range(5)
-#         cmd.index(test_index_data)
-#         mockindexable.index_items.assert_called_with(test_index_data, progbar=None)
-
-#         # solr connection exception should raise a command error
-#         with pytest.raises(CommandError):
-#             mockindexable.index_items.side_effect = Exception
-#             cmd.index(test_index_data)
-
-#     def test_clear(self):
-#         # index data into solr and catch  an error
-#         cmd = index.Command()
-#         cmd.solr = Mock()
-#         cmd.solr_collection = 'test'
-
-#         cmd.clear('all')
-#         cmd.solr.delete_doc_by_query.assert_called_with(cmd.solr_collection, '*:*')
-
-#         cmd.solr.reset_mock()
-#         cmd.clear('works')
-#         cmd.solr.delete_doc_by_query.assert_called_with(cmd.solr_collection, 'item_type:work')
-
-#         cmd.solr.reset_mock()
-#         cmd.clear('pages')
-#         cmd.solr.delete_doc_by_query.assert_called_with(cmd.solr_collection, 'item_type:page')
-
-#         cmd.solr.reset_mock()
-#         cmd.clear('foo')
-#         cmd.solr.delete_doc_by_query.assert_not_called()
-
-#         cmd.stdout = StringIO()
-#         cmd.verbosity = 3
-#         cmd.clear('works')
-#         assert cmd.stdout.getvalue() == 'Clearing works from the index'
-
-#     @patch('ppa.archive.management.commands.index.get_solr_connection')
-#     @patch('ppa.archive.management.commands.index.progressbar')
-#     @patch.object(index.Command, 'index')
-#     def test_call_command(self, mock_cmd_index_method, mockprogbar, mock_get_solr):
-#         mocksolr = Mock()
-#         test_coll = 'test'
-#         mock_get_solr.return_value = (mocksolr, test_coll)
-#         digworks = DigitizedWork.objects.all()
-
-#         stdout = StringIO()
-#         call_command('index', index='works', stdout=stdout)
-
-#         # index all works
-#         # (can't use assert_called_with because querysets doesn't evaluate equal)
-#         # mock_cmd_index_method.assert_called_with(digworks)
-#         args = mock_cmd_index_method.call_args[0]
-#         # first arg is queryset; compare them as lists
-#         assert list(digworks) == list(args[0])
-
-#         # not enough data to run progress bar
-#         mockprogbar.ProgressBar.assert_not_called()
-#         # commit called after works are indexed
-#         mocksolr.commit.assert_called_with(test_coll, openSearcher=True)
-#         # only called once (no pages)
-#         assert mock_cmd_index_method.call_count == 1
-
-#         with patch.object(DigitizedWork, 'page_index_data') as mock_page_index_data:
-#             mock_cmd_index_method.reset_mock()
-#             total_works = digworks.count()
-#             total_pages = sum(work.page_count for work in digworks)
-
-#             # simple number generator to test indexing in chunks
-#             def test_generator():
-#                 for i in range(155):
-#                     yield i
-
-#             mock_page_index_data.side_effect = test_generator
-
-#             call_command('index', index='pages', stdout=stdout)
-
-#             # progressbar should be called
-#             mockprogbar.ProgressBar.assert_called_with(
-#                 redirect_stdout=True, max_value=total_pages)
-#             # page index data called once for each work
-#             assert mock_page_index_data.call_count == total_works
-#             # progress bar updated called once for each work
-#             mockprogbar.ProgressBar.return_value.update.call_count = total_works
-#             # mock index called once for each work (chunking handled in Indexable)
-#             assert mock_cmd_index_method.call_count == total_works
-
-#             # request no progress bar
-#             mockprogbar.reset_mock()
-#             call_command('index', index='pages', no_progress=True, stdout=stdout)
-#             mockprogbar.ProgressBar.assert_not_called()
-
-#             # index both works and pages (default behavior)
-#             mock_cmd_index_method.reset_mock()
-#             mock_page_index_data.reset_mock()
-#             call_command('index', stdout=stdout)
-#             # progressbar should be called, total = works + pages
-#             mockprogbar.ProgressBar.assert_called_with(
-#                 redirect_stdout=True, max_value=total_works + total_pages)
-#             # called once for the works (all indexed in one batch) and
-#             # once for each set of pages in a work
-#             assert mock_cmd_index_method.call_count == total_works + 1
-#             # page index data called
-#             assert mock_page_index_data.call_count == total_works
-
-#             # index a single work by id
-#             work = digworks.first()
-#             mock_cmd_index_method.reset_mock()
-#             mock_page_index_data.reset_mock()
-#             call_command('index', work.source_id, stdout=stdout)
-#             mockprogbar.ProgressBar.assert_called_with(
-#                 redirect_stdout=True, max_value=1 + work.page_count)
-#             # called once for the work and once for the pages
-#             assert mock_cmd_index_method.call_count == 2
-#             # page index data called once only
-#             assert mock_page_index_data.call_count == 1
-
-#             # index nothing
-#             mock_cmd_index_method.reset_mock()
-#             mock_page_index_data.reset_mock()
-#             call_command('index', index='none', stdout=stdout)
-#             assert not mock_cmd_index_method.call_count
-#             assert not mock_page_index_data.call_count
-
-#     @patch('ppa.archive.management.commands.index.get_solr_connection')
-#     @patch('ppa.archive.management.commands.index.progressbar')
-#     @patch.object(index.Command, 'index')
-#     def test_skip_suppressed(self, mock_cmd_index_method, mockprogbar, mock_get_solr):
-#         mocksolr = Mock()
-#         test_coll = 'test'
-#         mock_get_solr.return_value = (mocksolr, test_coll)
-
-#         # mark one as suppressed
-#         work = DigitizedWork.objects.first()
-#         work.status = DigitizedWork.SUPPRESSED
-
-#         # skip hathi data deletion when suppressed
-#         with patch.object(work, 'hathi'):
-#             work.save()
-
-#         # digworks = DigitizedWork.objects.filter(status=DigitizedWork.PUBLIC)
-
-#         stdout = StringIO()
-#         call_command('index', index='works', stdout=stdout)
-
-#         # index all works
-#         # (can't use assert_called_with because querysets doesn't evaluate equal)
-#         # mock_cmd_index_method.assert_called_with(digworks)
-#         args = mock_cmd_index_method.call_args[0]
-#         # first arg is queryset; compare them as lists
-#         # assert list(digworks) == list(args[0])
-#         assert work not in list(args[0])
-
 
 class TestHathiAddCommand(TestCase):
     fixtures = ['sample_digitized_works']
@@ -455,3 +295,79 @@ class TestHathiAddCommand(TestCase):
         # success by pid
         assert '%s - successfully added' % test_htid not in output
 
+
+# test index pages command and methods
+
+
+@patch('ppa.archive.management.commands.index_pages.Page')
+def test_page_index_data(mock_page):
+    work_q = Mock()
+    page_q = Mock()
+    digwork1 = Mock()
+    digwork2 = Mock()
+    # return two mock works and then raise queue empty
+    work_q.get.side_effect = (digwork1, digwork2, queue.Empty)
+
+    index_pages.page_index_data(work_q, page_q)
+
+    assert work_q.get.call_count == 3
+    work_q.get.assert_called_with(timeout=1)
+    assert page_q.put.call_count == 2
+    page_q.put.assert_any_call(list(mock_page.page_index_data.return_value))
+    page_q.put.assert_any_call(list(mock_page.page_index_data.return_value))
+    mock_page.page_index_data.assert_any_call(digwork1)
+    mock_page.page_index_data.assert_any_call(digwork2)
+
+
+@patch('ppa.archive.management.commands.index_pages.progressbar')
+@patch('ppa.archive.management.commands.index_pages.SolrClient')
+def test_process_index_queue(mock_solrclient, mock_progbar):
+    work_q = Mock()
+    index_q = Mock()
+    mockdata1 = ['a', 'b', 'c', 'd']
+    mockdata2 = ['y', 'y', 'z']
+    # simulate indexer catching up with page index loading
+    # - return data, empty, more data, then empty
+    index_q.get.side_effect = (mockdata1, queue.Empty, mockdata2, queue.Empty)
+    # not empty the first time, empty the second
+    work_q.empty.side_effect = (False, True)
+    total = 10
+    index_pages.process_index_queue(index_q, total, work_q)
+
+    assert index_q.get.call_count == 4
+    assert work_q.empty.call_count == 2
+    index_q.get.assert_called_with(timeout=5)
+
+    mock_solrclient.return_value.update.index.assert_any_call(mockdata1)
+    mock_solrclient.return_value.update.index.assert_any_call(mockdata2)
+
+    mock_progbar.ProgressBar.assert_called_with(redirect_stdout=True,
+                                                max_value=total)
+    progbar = mock_progbar.ProgressBar.return_value
+    progbar.update.assert_any_call(4)
+    progbar.update.assert_any_call(7)
+    progbar.finish.assert_called_with()
+
+
+class TestIndexPagesCommand(TestCase):
+    fixtures = ['sample_digitized_works']
+
+    @patch('ppa.archive.management.commands.index_pages.sleep')
+    @patch('ppa.archive.management.commands.index_pages.progressbar')
+    def test_index_pages(self, mock_progbar, mock_sleep):
+        # test calling from command line
+        stdout = StringIO()
+        call_command('index_pages', stdout=stdout)
+        output = stdout.getvalue()
+        assert 'Indexing with %d processes' % cpu_count() in output
+        assert 'Items in Solr by item type: %d pages' % Page.total_to_index()
+
+    @patch('ppa.archive.management.commands.index_pages.sleep')
+    @patch('ppa.archive.management.commands.index_pages.progressbar')
+    def test_index_pages_no_verbosity(self, mock_progbar, mock_sleep):
+        # test calling from command line
+        stdout = StringIO()
+        call_command('index_pages', stdout=stdout, verbosity=0)
+        output = stdout.getvalue()
+        assert 'Indexing with' not in output
+        assert 'Items in Solr' not in output


### PR DESCRIPTION
Custom page indexing script with multiprocessing.

Haven't written any unit tests yet because I wanted to get feedback first. 

Would love to get reports on index times & cpu count on your machines; also interested in comparison with index time before, if you remember roughly what it was. 