### PR TITLE
hover/focus state changes

### DIFF
--- a/sitemedia/semantic/src/site/elements/button.overrides
+++ b/sitemedia/semantic/src/site/elements/button.overrides
@@ -41,4 +41,9 @@
         color: @disabledTextColor;
         border-color: @disabledTextColor;
     }
+
+    &.focus,
+    &:focus {
+        outline: @focusOutline;
+    }
 }

--- a/sitemedia/semantic/src/site/elements/button.variables
+++ b/sitemedia/semantic/src/site/elements/button.variables
@@ -32,6 +32,7 @@
 /* Focused */
 @focusBackgroundColor: @primaryColor;
 @focusColor: @invertedTextColor;
+@focusOutline: 2px dashed black;
 
 /* Pressed Down */
 @downBackgroundColor: @primaryColor;

--- a/srcmedia/scss/_mixins.scss
+++ b/srcmedia/scss/_mixins.scss
@@ -279,14 +279,14 @@
     }
 }
 
-@mixin triangle-overlay($color) {
+@mixin triangle-overlay($color, $size) {
     height: 0;
     width: 0;
-    left: calc(100% - 50px);
-    border-right: 25px solid $color;
-    border-bottom: 25px solid $color;
-    border-top: 25px solid transparent;
-    border-left: 25px solid transparent;
+    left: calc(100% - #{$size});
+    border-right: calc(#{$size} / 2) solid $color;
+    border-bottom: calc(#{$size} / 2) solid $color;
+    border-top: calc(#{$size} / 2) solid transparent;
+    border-left: calc(#{$size} / 2) solid transparent;
     z-index: -1;
     opacity: 0.5;
 }

--- a/srcmedia/scss/snippets/_links.scss
+++ b/srcmedia/scss/snippets/_links.scss
@@ -39,6 +39,7 @@ a.archive-link { // "view the archive" button
     width: 30px;
     box-shadow: 0 0 6px 0 $french-blue;
     z-index: 10;
+    text-decoration: none;
 
     @media (min-width: $largeMonitor) {
         left: calc(50% + #{$largeMonitor} / 2 - 4rem);

--- a/srcmedia/scss/snippets/_nav.scss
+++ b/srcmedia/scss/snippets/_nav.scss
@@ -180,24 +180,54 @@
         }
 
         &.about.triangle::before {
-            @include triangle-overlay($rosy-pink);
+            @include triangle-overlay($rosy-pink, 54px);
         }
 
         &.editorial.active::before {
-            @include triangle-overlay($twilight);
+            @include triangle-overlay($twilight, 54px);
         }
 
         &.collections,
         &.archive {
             &.active::before {
-                @include triangle-overlay($seafoam-blue);
+                @include triangle-overlay($seafoam-blue, 54px);
+            }
+        }
+
+        // grey hover/focus triangle overlay for main nav menu items
+        &.collections,
+        &.archive,
+        &.editorial {
+            &.focus::before,
+            &:focus::before,
+            &:hover::before {
+                @include triangle-overlay($white, 54px);
+                opacity: 1;
             }
         }
     }
 
-    a.item:hover {
-        border-bottom: 10px solid $french-blue;
-        padding-bottom: 8px;
+    // smaller hover/focus triangle for items in the about menu
+    .submenu .item:focus-within::before,
+    .about .item:hover::before {
+        display: block;
+        @include triangle-overlay($white, 40px);
+        opacity: 1;
+    }
+
+    // PPA logo/brand has smaller triangle shifted to the bottom; no hover
+    .brand .item:focus::before,
+    .brand .item.focus::before {
+        top: 54px;
+        @include triangle-overlay($white, 42px);
+        opacity: 1;
+    }
+
+    // remove default outline focus indicator
+    a.item:focus,
+    a.item.focus,
+    .item a:focus {
+        outline: none;
     }
 
     .search .search.icon {

--- a/templates/snippets/about.html
+++ b/templates/snippets/about.html
@@ -1,9 +1,9 @@
 {% load static %}
 
 <div class="about ui simple item dropdown{% if active == 'about' %} triangle{% endif %}">
-    <div tabindex=0 class="text">About</div>
+    <div class="text">About</div>
     <img class="dropdown icon" src="{% static 'img/icons/RightChevron.svg' %}" alt="">
-    <div class="menu">
+    <div class="menu submenu">
         {# NOTE: currently relies on editorial not having show_in_menu set #}
         {% for page in request.site.root_page.get_children.live.in_menu %}
         <div class="item"><a href="{{ page.url }}">{{ page.title }}</a></div>


### PR DESCRIPTION
this PR:

- adds a dashed black focus indicator for buttons
- adds a grey triangle as an indicator of hover/focus states for each of the main nav items
- adds the same indicator to the items in the "about" submenu (but not the "about" item itself)
- ensures that the "about" item isn't independently focusable

I applied the triangle to the bottom of the PPA logotype when it is focused; lmk if that isn't a reasonable interpretation of the style. See attached video where I hover each of the items, and then focus through each of them using the <kbd>tab</kbd> key.

https://user-images.githubusercontent.com/4924494/118861612-b248d200-b8aa-11eb-8537-7bc2cf865b61.mov

Note also that the order that you <kbd>tab</kbd> focus through the collections buttons is not the order they appear! This is unavoidable; we used special CSS to rearrange the buttons dynamically when they are selected/unselected but that styling doesn't correlate to DOM order. We don't want to rearrange the actual elements in the DOM since that would require javascript. See attached video:


https://user-images.githubusercontent.com/4924494/118862263-82e69500-b8ab-11eb-94c1-cebab9d6785e.mov

