### PR TITLE
Gale/ECCO thumbnails

### DIFF
--- a/ppa/archive/models.py
+++ b/ppa/archive/models.py
@@ -338,8 +338,8 @@ class DigitizedWork(TrackChangesModel, ModelIndexable):
     @property
     def has_fulltext(self):
         '''Checks if an item has full text (currently only items from
-        HathiTrust).'''
-        return self.source == self.HATHI
+        HathiTrust or Gale).'''
+        return self.source in [self.HATHI, self.GALE]
 
     @cached_property
     def hathi(self):

--- a/ppa/archive/models.py
+++ b/ppa/archive/models.py
@@ -576,6 +576,7 @@ class DigitizedWork(TrackChangesModel, ModelIndexable):
         return {
             'id': self.source_id,
             'source_id': self.source_id,
+            'source_t': self.get_source_display(),
             'source_url': self.source_url,
             'title': self.title,
             'subtitle': self.subtitle,

--- a/ppa/archive/solr.py
+++ b/ppa/archive/solr.py
@@ -108,7 +108,7 @@ class ArchiveSearchQuerySet(SolrQuerySet):
     field_list = [
         'id', 'author', 'pubdate', 'publisher', 'enumcron', 'order',
         'source_id', 'label', 'title', 'subtitle', 'score', 'pub_date',
-        'collections'
+        'collections', 'source_t', 'image_id_s'
     ]
 
     keyword_query = None

--- a/ppa/archive/templates/archive/snippets/page_preview.html
+++ b/ppa/archive/templates/archive/snippets/page_preview.html
@@ -12,6 +12,7 @@ Expected context variables:
     <div class="preview">
         <a href="{% page_url item_id page.order %}"
           target="_blank" rel="noopener noreferrer">
+          {% if source == 'Hathi' %}
           {% page_image_url item_id page.order 225 as 1x_img %}
           {% page_image_url item_id page.order 450 as 2x_img %}
           {# img with data-src/srcset attributes for lazy-loading  #}
@@ -22,6 +23,9 @@ Expected context variables:
             <img src="{{ 1x_img }}" srcset="{{ 1x_img}}, {{ 2x_img }} 2x"
               alt="page {{ page.label }}"/>
           </noscript>
+          {% elif source == 'Gale' %}
+          <img src="https://callisto.ggsrv.com/imgsrv/FastFetch/UBER2/{{ image_id }}-T2" alt="page {{ page.label }}"/>
+          {% endif %}
         </a>
     </div>
     {% if page.title %}<a>p. {{ page.title }}</a>{% endif %}

--- a/ppa/archive/templates/archive/snippets/page_preview.html
+++ b/ppa/archive/templates/archive/snippets/page_preview.html
@@ -12,7 +12,7 @@ Expected context variables:
     <div class="preview">
         <a href="{% page_url item_id page.order %}"
           target="_blank" rel="noopener noreferrer">
-          {% if source == 'Hathi' %}
+          {% if source == 'HathiTrust' %}
           {% page_image_url item_id page.order 225 as 1x_img %}
           {% page_image_url item_id page.order 450 as 2x_img %}
           {# img with data-src/srcset attributes for lazy-loading  #}

--- a/ppa/archive/templates/archive/snippets/page_preview.html
+++ b/ppa/archive/templates/archive/snippets/page_preview.html
@@ -24,6 +24,7 @@ Expected context variables:
               alt="page {{ page.label }}"/>
           </noscript>
           {% elif source == 'Gale' %}
+          {# provisional implementation; waiting on details for slightly higher resolution options #}
           <img src="https://callisto.ggsrv.com/imgsrv/FastFetch/UBER2/{{ image_id }}-T2" alt="page {{ page.label }}"/>
           {% endif %}
         </a>

--- a/ppa/archive/templates/archive/snippets/page_preview.html
+++ b/ppa/archive/templates/archive/snippets/page_preview.html
@@ -24,8 +24,11 @@ Expected context variables:
               alt="page {{ page.label }}"/>
           </noscript>
           {% elif source == 'Gale' %}
-          {# provisional implementation; waiting on details for slightly higher resolution options #}
-          <img src="https://callisto.ggsrv.com/imgsrv/FastFetch/UBER2/{{ image_id }}-T2" alt="page {{ page.label }}"/>
+          {# TODO: move to template tag? combine or separate from hathi? #}
+          {% with 2x_img="https://callisto.ggsrv.com/imgsrv/FastFetch/UBER2/"|add:image_id|add:"?format=jpg&boundbox=725+450" 1x_img="https://callisto.ggsrv.com/imgsrv/FastFetch/UBER2/"|add:image_id|add:"?format=jpg&boundbox=180+225" %}
+          <img src="{{ 1x_img }}" srcset="{{ 1x_img}}, {{ 2x_img }} 2x"
+              alt="page {{ page.label }}"/>
+          {% endwith %}
           {% endif %}
         </a>
     </div>

--- a/ppa/archive/templates/archive/snippets/page_preview.html
+++ b/ppa/archive/templates/archive/snippets/page_preview.html
@@ -24,7 +24,7 @@ Expected context variables:
               alt="page {{ page.label }}"/>
           </noscript>
           {% elif source == 'Gale' %}
-          {# TODO: move to template tag? combine or separate from hathi? #}
+          {# NOTE: may want to move to a template tag at some point #}
           {% with 2x_img="https://callisto.ggsrv.com/imgsrv/FastFetch/UBER2/"|add:image_id|add:"?format=jpg&boundbox=725+450" 1x_img="https://callisto.ggsrv.com/imgsrv/FastFetch/UBER2/"|add:image_id|add:"?format=jpg&boundbox=180+225" %}
           <img src="{{ 1x_img }}" srcset="{{ 1x_img}}, {{ 2x_img }} 2x"
               alt="page {{ page.label }}"/>

--- a/ppa/archive/templates/archive/snippets/results_within_list.html
+++ b/ppa/archive/templates/archive/snippets/results_within_list.html
@@ -18,7 +18,7 @@
             <div class="ui page item">
                 <div class="pages ui twelve wide column">
                     <div class="wrapper">
-                        {% include 'archive/snippets/page_preview.html' with item_id=page.source_id  %}
+                        {% include 'archive/snippets/page_preview.html' with item_id=page.source_id  source=object.get_source_display image_id=page.image_id_s %}
                     </div>
                 </div>
             </div>

--- a/ppa/archive/templates/archive/snippets/search_result.html
+++ b/ppa/archive/templates/archive/snippets/search_result.html
@@ -88,7 +88,7 @@
                 <div class="wrapper">
                     {% for page in results.docs %}
                     {% with highlights=page_highlights|dict_item:page.id %}
-                        {% include 'archive/snippets/page_preview.html' with item_id=item.source_id  %}
+                        {% include 'archive/snippets/page_preview.html' with item_id=item.source_id source=item.source_t.0 image_id=page.image_id_s%}
                     {% endwith %}
                     {% endfor %}
                 </div>

--- a/ppa/archive/tests/test_models.py
+++ b/ppa/archive/tests/test_models.py
@@ -386,6 +386,7 @@ class TestDigitizedWork(TestCase):
         index_data = digwork.index_data()
         assert index_data['id'] == digwork.source_id
         assert index_data['source_id'] == digwork.source_id
+        assert index_data['source_t'] == digwork.get_source_display()
         assert index_data['item_type'] == 'work'
         assert index_data['title'] == digwork.title
         assert index_data['subtitle'] == digwork.subtitle

--- a/ppa/archive/tests/test_models.py
+++ b/ppa/archive/tests/test_models.py
@@ -102,6 +102,9 @@ class TestDigitizedWork(TestCase):
         digwork.source = DigitizedWork.OTHER
         # for non-hathi items, shouldn't have full text
         assert not digwork.has_fulltext
+        # new Gale/ECCO content is full text
+        digwork.source = DigitizedWork.GALE
+        assert digwork.has_fulltext
 
     def test_hathi(self):
         digwork = DigitizedWork(source_id='njp.32101013082597',

--- a/ppa/archive/tests/test_views.py
+++ b/ppa/archive/tests/test_views.py
@@ -46,7 +46,8 @@ class TestDigitizedWorkDetailView(TestCase):
         htid = 'chi.78013704'
         solr_page_docs = [
             {'content': content, 'order': i + 1, 'item_type': 'page',
-             'source_id': htid, 'id': '%s.%s' % (htid, i), 'label': i}
+             'source_id': htid, 'id': '%s.%s' % (htid, i), 'label': i,
+             'source_t': 'HathiTrust'}
             for i, content in enumerate(sample_page_content)]
         # dial = DigitizedWork.objects.get(source_id='chi.78013704')
         # solr_work_docs = [dial.index_data()]

--- a/ppa/archive/views.py
+++ b/ppa/archive/views.py
@@ -272,8 +272,8 @@ class DigitizedWorkDetailView(AjaxTemplateMixin, SolrLastModifiedMixin,
             'query': query
         })
 
-        # search within a volume currently only supported for hathi content
-        if query and digwork.source == DigitizedWork.HATHI:
+        # search within a volume only supported for content with full text
+        if query and digwork.has_fulltext:
             # search on the specified search terms,
             # filter on digitized work source id and page type,
             # sort by page order,
@@ -283,7 +283,7 @@ class DigitizedWorkDetailView(AjaxTemplateMixin, SolrLastModifiedMixin,
                 .search(content='(%s)' % query) \
                 .filter(source_id='"%s"' % digwork.source_id,
                         item_type='page') \
-                .only('id', 'source_id', 'order', 'title', 'label') \
+                .only('id', 'source_id', 'order', 'title', 'label', 'image_id_s') \
                 .highlight('content*', snippets=3, method='unified') \
                 .order_by('order')
 
@@ -301,9 +301,9 @@ class DigitizedWorkDetailView(AjaxTemplateMixin, SolrLastModifiedMixin,
                     # add highlights to context
                     'page_highlights': highlights
                 })
+
             except requests.exceptions.ConnectionError:
                 context['error'] = 'Something went wrong.'
-
         return context
 
 

--- a/ppa/settings.py
+++ b/ppa/settings.py
@@ -265,9 +265,9 @@ CSP_FONT_SRC = ("'self'", 'https://fonts.gstatic.com data:')
 CSP_STYLE_SRC = ("'self'", 'https://fonts.googleapis.com',
                  '*.glitch.me')
 
-# allow loading local images, hathi page images, google tracking pixel
+# allow loading local images, hathi page images, google tracking pixel, gale images
 CSP_IMG_SRC = ("'self'", 'https://babel.hathitrust.org',
-               'https://www.google-analytics.com')
+               'https://www.google-analytics.com', 'https://callisto.ggsrv.com')
 
 # exclude admin and cms urls from csp directives since they're authenticated
 CSP_EXCLUDE_URL_PREFIXES = ('/admin', '/cms')


### PR DESCRIPTION
Adjust indexing and page preview template so we can display thumbnails for Gale content

In the process of getting thumbnails working for the search within a single document, I also made the small changes needed for that to work with Gale content #377