### PR TITLE
Improve Gale API and import script error handling

### DIFF
--- a/ppa/archive/gale.py
+++ b/ppa/archive/gale.py
@@ -139,6 +139,11 @@ class GaleAPI:
             # NOTE that item requests for invalid ids may return 403
             raise GaleItemForbidden(resp.json()["message"])
 
+        else:
+            # getting 406 not acceptable in some cases
+            # (attempt to access item with invalid item id)
+            raise GaleAPIError(resp.status_code)
+
     def get_api_key(self):
         """Get a new API key to use for requests in the next 30 minutes."""
         # GALE API requires use of an API key, which lasts for 30 minutes

--- a/ppa/archive/gale.py
+++ b/ppa/archive/gale.py
@@ -139,10 +139,10 @@ class GaleAPI:
             # NOTE that item requests for invalid ids may return 403
             raise GaleItemForbidden(resp.json()["message"])
 
-        else:
-            # getting 406 not acceptable in some cases
-            # (attempt to access item with invalid item id)
-            raise GaleAPIError(resp.status_code)
+        # raise anything else as a generic error with status code
+        # getting 406 not acceptable in some cases
+        # (attempt to access item with invalid item id)
+        raise GaleAPIError(resp.status_code)
 
     def get_api_key(self):
         """Get a new API key to use for requests in the next 30 minutes."""

--- a/ppa/archive/management/commands/gale_import.py
+++ b/ppa/archive/management/commands/gale_import.py
@@ -83,7 +83,7 @@ class Command(BaseCommand):
             raise CommandError("A list of IDs or CSV file for is required for import")
 
         # error handling in case user forgets to specify csv file correctly
-        if kwargs.get('id') and len(kwargs['ids']) == 1 and kwargs['ids'][0].endswith('.csv'):
+        if 'ids' in kwargs and len(kwargs['ids']) == 1 and kwargs['ids'][0].endswith('.csv'):
             self.stdout.write(self.style.WARNING(
                 '%s is not a valid id; did you forget to specify -c/--csv?' % kwargs['ids'][0]))
             return

--- a/ppa/archive/management/commands/gale_import.py
+++ b/ppa/archive/management/commands/gale_import.py
@@ -82,6 +82,12 @@ class Command(BaseCommand):
         if not (kwargs["ids"] or kwargs["csv"]):
             raise CommandError("A list of IDs or CSV file for is required for import")
 
+        # error handling in case user forgets to specify csv file correctly
+        if kwargs.get('id') and len(kwargs['ids']) == 1 and kwargs['ids'][0].endswith('.csv'):
+            self.stdout.write(self.style.WARNING(
+                '%s is not a valid id; did you forget to specify -c/--csv?' % kwargs['ids'][0]))
+            return
+
         # NOTE: could disconnect indexing signals for more control over indexing
         # for now, leaving signal-based indexing on
 

--- a/ppa/archive/tests/test_gale.py
+++ b/ppa/archive/tests/test_gale.py
@@ -212,6 +212,7 @@ class TestGaleAPI(TestCase):
         # json response is returned on success
         assert item == gale_api.session.get.return_value.json.return_value
 
-        # simulate invalid request that doesn't raise an exception
+        # simulate invalid request that raises a generic exception
         gale_api.session.get.return_value.status_code = requests.codes.bad_request
-        assert gale_api.get_item("CW123456") is None
+        with pytest.raises(gale.GaleAPIError):
+            gale_api.get_item("CW123456")

--- a/ppa/archive/tests/test_gale_import.py
+++ b/ppa/archive/tests/test_gale_import.py
@@ -49,7 +49,7 @@ class TestGaleImportCommand:
 
         stdout = StringIO()
         cmd = gale_import.Command(stdout=stdout)
-        cmd.handle(ids=None, csv=csvfile)
+        cmd.handle(ids=[], csv=csvfile)
         mock_import_digwork.assert_any_call("12345", NOTES="brief mention in footnotes")
         assert cmd.stats["total"] == 1
         output = stdout.getvalue()
@@ -252,3 +252,9 @@ class TestGaleImportCommand:
         # ImproperlyConfigured api error should be raised as command error
         with pytest.raises(CommandError):
             gale_import.Command().handle(ids=[], csv=None)
+
+    def test_call_with_csv_as_id(self):
+        stdout = StringIO()
+        gale_import.Command(stdout=stdout).handle(ids=['path/to/file.csv'], csv=None)
+        output = stdout.getvalue()
+        assert 'not a valid id; did you forget to specify -c/--csv?' in output


### PR DESCRIPTION
This error handling is for me — I keep forgetting to specify `-c` when I give it a csv file and so it tries to treat the csv as an item, which errors.  

I also decided that any non-ok response should raise an api error rather than return none.