### PR TITLE
Suppress underline on 'view the archive' button link

### DIFF
--- a/srcmedia/scss/pages/_home.scss
+++ b/srcmedia/scss/pages/_home.scss
@@ -27,6 +27,7 @@
 
     .archive-link {
         margin: 0 0 2rem;
+        text-decoration: none;
     }
 
     .asides-collections {

--- a/srcmedia/scss/pages/_list-collections.scss
+++ b/srcmedia/scss/pages/_list-collections.scss
@@ -16,6 +16,7 @@
 
     .archive-link {
         margin: 2rem auto;
+        text-decoration: none;
     }
 
     .collection-cards {


### PR DESCRIPTION
@thatbudakguy is there a better way to do this? 

there's an `a.archive-link` in _links.scss that specifies no underline, but the `a:not(.ui):not(.card)` style seems to be taking precedence