### PR TITLE
Add & test logic to link to specific pages on Gale

### DIFF
--- a/ppa/archive/models.py
+++ b/ppa/archive/models.py
@@ -934,6 +934,10 @@ class Page(Indexable):
         making an extra API call if data is already available."""
         if gale_record is None:
             gale_record = GaleAPI().get_item(digwork.source_id)
+        # NOTE when adding support for excerpts from Gale, we should
+        # ensure that order is set based on the sequence of images within the volume
+        # (not within the excerpt), since order is used to generate
+        # the link directly to specific pages on Gale
         for i, page in enumerate(gale_record["pageResponse"]["pages"], 1):
             page_number = page["pageNumber"]
             page_num_int = int(page_number)

--- a/ppa/archive/solr.py
+++ b/ppa/archive/solr.py
@@ -126,6 +126,7 @@ class ArchiveSearchQuerySet(SolrQuerySet):
         "collections",
         "source_t",
         "image_id_s",
+        "source_url",
     ]
 
     keyword_query = None

--- a/ppa/archive/templates/archive/snippets/page_preview.html
+++ b/ppa/archive/templates/archive/snippets/page_preview.html
@@ -9,8 +9,14 @@ Expected context variables:
 {% endcomment %}
 {% load ppa_tags %}
 <div class="page">
+  {% if source == 'HathiTrust' %}
+    {% hathi_page_url item_id page.order as page_link %}
+  {% elif source == 'Gale' %}
+    {% gale_page_url source_url page.order as page_link %}
+  {# currently no other sources with page level content, so no other case needed #}
+  {% endif %}
     <div class="preview">
-        <a href="{% page_url item_id page.order %}"
+        <a href="{{ page_link }}"
           target="_blank" rel="noopener noreferrer">
           {% if source == 'HathiTrust' %}
           {% page_image_url item_id page.order 225 as 1x_img %}
@@ -35,7 +41,7 @@ Expected context variables:
     {% if page.title %}<a>p. {{ page.title }}</a>{% endif %}
     <div class="snippets">
           <p class="page-number">
-            <a href="{% page_url item_id page.order %}" target="_blank" rel="noopener noreferrer">
+            <a href="{{ page_link }}" target="_blank" rel="noopener noreferrer">
               p. {{ page.label }}
             </a>
           </p>

--- a/ppa/archive/templates/archive/snippets/results_within_list.html
+++ b/ppa/archive/templates/archive/snippets/results_within_list.html
@@ -18,7 +18,7 @@
             <div class="ui page item">
                 <div class="pages ui twelve wide column">
                     <div class="wrapper">
-                        {% include 'archive/snippets/page_preview.html' with item_id=page.source_id  source=object.get_source_display image_id=page.image_id_s %}
+                        {% include 'archive/snippets/page_preview.html' with item_id=page.source_id  source=object.get_source_display image_id=page.image_id_s source_url=object.source_url %}
                     </div>
                 </div>
             </div>

--- a/ppa/archive/templates/archive/snippets/search_result.html
+++ b/ppa/archive/templates/archive/snippets/search_result.html
@@ -88,7 +88,7 @@
                 <div class="wrapper">
                     {% for page in results.docs %}
                     {% with highlights=page_highlights|dict_item:page.id %}
-                        {% include 'archive/snippets/page_preview.html' with item_id=item.source_id source=item.source_t.0 image_id=page.image_id_s%}
+                        {% include 'archive/snippets/page_preview.html' with item_id=item.source_id source=item.source_t.0 image_id=page.image_id_s source_url=item.source_url %}
                     {% endwith %}
                     {% endfor %}
                 </div>

--- a/ppa/archive/templatetags/ppa_tags.py
+++ b/ppa/archive/templatetags/ppa_tags.py
@@ -66,13 +66,20 @@ def page_image_url(item_id, order, width):
 
 
 @register.simple_tag
-def page_url(item_id, order):
+def hathi_page_url(item_id, order):
     """Generate a link to HathiTrust for an individual page
     Example use::
 
         {% page_url item_id page.order %}
     """
     return "{}/pt?id={};view=1up;seq={}".format(HATHI_BASE_URL, item_id, order)
+
+
+@register.simple_tag
+def gale_page_url(item_url, order):
+    # add page number to existing source url (i.e., isShownAt URL from API);
+    # (assumes that url already has some query parameters, as they currently always do)
+    return "{}&pg={}".format(item_url, order)
 
 
 #: regular expression to identify open and close <em> tags in solr

--- a/ppa/archive/tests/test_templatetags.py
+++ b/ppa/archive/tests/test_templatetags.py
@@ -76,14 +76,6 @@ def test_hathi_page_url():
     assert hathi_url.endswith("?id=%s;view=1up;seq=%s" % (item_id, order))
 
 
-def test_hathi_page_url():
-    item_id = "mdp.39015031594768"
-    order = 50
-    hathi_url = hathi_page_url(item_id, order)
-    assert hathi_url.startswith("%s/pt" % HATHI_BASE_URL)
-    assert hathi_url.endswith("?id=%s;view=1up;seq=%s" % (item_id, order))
-
-
 def test_gale_page_url():
     source_url = "https://link.gale.com/apps/doc/CW0123455/ECCO?u=abc123&sid=gale_api&xid=1605fa6c"
     order = 248

--- a/ppa/archive/tests/test_templatetags.py
+++ b/ppa/archive/tests/test_templatetags.py
@@ -6,8 +6,9 @@ from django.utils.safestring import SafeString
 from ppa.archive.templatetags.ppa_tags import (
     HATHI_BASE_URL,
     dict_item,
+    gale_page_url,
+    hathi_page_url,
     page_image_url,
-    page_url,
     querystring_replace,
     solr_highlight,
 )
@@ -67,12 +68,27 @@ def test_page_image_url():
     assert img_url.startswith("%s/imgsrv/thumbnail?" % HATHI_BASE_URL)
 
 
-def test_page_url():
+def test_hathi_page_url():
     item_id = "mdp.39015031594768"
     order = 50
-    hathi_url = page_url(item_id, order)
+    hathi_url = hathi_page_url(item_id, order)
     assert hathi_url.startswith("%s/pt" % HATHI_BASE_URL)
     assert hathi_url.endswith("?id=%s;view=1up;seq=%s" % (item_id, order))
+
+
+def test_hathi_page_url():
+    item_id = "mdp.39015031594768"
+    order = 50
+    hathi_url = hathi_page_url(item_id, order)
+    assert hathi_url.startswith("%s/pt" % HATHI_BASE_URL)
+    assert hathi_url.endswith("?id=%s;view=1up;seq=%s" % (item_id, order))
+
+
+def test_gale_page_url():
+    source_url = "https://link.gale.com/apps/doc/CW0123455/ECCO?u=abc123&sid=gale_api&xid=1605fa6c"
+    order = 248
+    gale_url = gale_page_url(source_url, order)
+    assert gale_url == "%s&pg=248" % source_url
 
 
 def test_solr_highlight():

--- a/ppa/archive/tests/test_views.py
+++ b/ppa/archive/tests/test_views.py
@@ -25,7 +25,7 @@ from ppa.archive.forms import (
 )
 from ppa.archive.models import NO_COLLECTION_LABEL, Collection, DigitizedWork
 from ppa.archive.solr import ArchiveSearchQuerySet
-from ppa.archive.templatetags.ppa_tags import page_image_url, page_url
+from ppa.archive.templatetags.ppa_tags import hathi_page_url, page_image_url
 from ppa.archive.views import AddFromHathiView, DigitizedWorkCSV, DigitizedWorkListView
 
 
@@ -310,7 +310,7 @@ class TestDigitizedWorkDetailView(TestCase):
         # image should have a link to hathitrust as should the page number
         self.assertContains(
             response,
-            page_url(result["source_id"], result["order"]),
+            hathi_page_url(result["source_id"], result["order"]),
             count=2,
             msg_prefix="should include a link to HathiTrust",
         )


### PR DESCRIPTION
ref #374

- rename existing `page_url` template tag to `hathi_page_url`
- add new, equivalent `gale_page_url` template tag to generate page-level links for gale content