### PR TITLE
Filter single-document search on group id #401

### DIFF
--- a/ppa/archive/tests/test_views.py
+++ b/ppa/archive/tests/test_views.py
@@ -55,6 +55,7 @@ class TestDigitizedWorkDetailView(TestCase):
                 "id": "%s.%s" % (htid, i),
                 "label": i,
                 "source_t": "HathiTrust",
+                "group_id_s": htid,
             }
             for i, content in enumerate(sample_page_content)
         ]

--- a/ppa/archive/views.py
+++ b/ppa/archive/views.py
@@ -336,7 +336,7 @@ class DigitizedWorkDetailView(AjaxTemplateMixin, SolrLastModifiedMixin, DetailVi
             solr_pageq = (
                 SolrQuerySet()
                 .search(content="(%s)" % query)
-                .filter(source_id='"%s"' % digwork.source_id, item_type="page")
+                .filter(group_id_s='"%s"' % digwork.index_id(), item_type="page")
                 .only("id", "source_id", "order", "title", "label", "image_id_s")
                 .highlight("content*", snippets=3, method="unified")
                 .order_by("order")


### PR DESCRIPTION
Filter on group id instead of source id so behavior will work properly for excerpts, even if there are multiple excerpts from the same source.