### PR TITLE
new manage command to convert HathiTrust digitized works into excerpts

### DIFF
--- a/ppa/archive/management/commands/hathi_excerpt.py
+++ b/ppa/archive/management/commands/hathi_excerpt.py
@@ -121,11 +121,20 @@ class Command(BaseCommand):
 
         if created:
             self.stats["created"] += 1
-            # log entry details
+        else:
+            self.stats["excerpted"] += 1
+
+        self.log_action(digwork, created)
+
+        # TODO: make sure work & pages are updated in solr index
+
+    def log_action(self, digwork, created=True):
+        """Create a log entry to document excerpting or creating the record.
+        Message and action flag are determined by created boolean."""
+        if created:
             log_message = "Created via hathi_excerpt script"
             log_action = ADDITION
         else:
-            self.stats["excerpted"] += 1
             log_message = "Converted to excerpt"
             log_action = CHANGE
 
@@ -138,8 +147,6 @@ class Command(BaseCommand):
             change_message=log_message,
             action_flag=log_action,
         )
-
-        # TODO: make sure work & pages are updated in solr index
 
     csv_required_fields = [
         "Item Type",

--- a/ppa/archive/management/commands/hathi_excerpt.py
+++ b/ppa/archive/management/commands/hathi_excerpt.py
@@ -91,7 +91,9 @@ class Command(BaseCommand):
         digwork.record_id = row["Record ID"]
         # - optional fields
         digwork.author = row.get("Author", "")
-        digwork.pub_date = row.get("Publication Date", None)  # numeric, not string
+        digwork.pub_date = (
+            row.get("Publication Date", "") or None
+        )  # numeric, not string
         digwork.pub_place = row.get("Publication Place", "")
         digwork.publisher = row.get("Publisher", "")
         digwork.enumcron = row.get("Enumcron", "")

--- a/ppa/archive/management/commands/hathi_excerpt.py
+++ b/ppa/archive/management/commands/hathi_excerpt.py
@@ -1,0 +1,157 @@
+import csv
+from collections import Counter
+
+import intspan
+from django.conf import settings
+from django.contrib.admin.models import ADDITION, CHANGE, LogEntry
+from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
+from django.core.management.base import BaseCommand, CommandError
+from parasolr.django.signals import IndexableSignalHandler
+
+from ppa.archive.models import Collection, DigitizedWork
+
+
+class Command(BaseCommand):
+    """Convert existing HathiTrust full works into excerpts"""
+
+    help = __doc__
+
+    #: normal verbosity level
+    v_normal = 1
+    verbosity = v_normal
+
+    # item type lookup for supported types
+    item_type = {"Excerpt": DigitizedWork.EXCERPT, "Article": DigitizedWork.ARTICLE}
+
+    def add_arguments(self, parser):
+        parser.add_argument("csv", help="CSV file with excerpt information")
+
+    def handle(self, *args, **kwargs):
+        # disconnect signal handler so indexing can be controlled
+        IndexableSignalHandler.disconnect()
+
+        self.verbosity = kwargs.get("verbosity", self.v_normal)
+        self.stats = Counter()
+        self.script_user = User.objects.get(username=settings.SCRIPT_USERNAME)
+        self.digwork_contentype = ContentType.objects.get_for_model(DigitizedWork)
+
+        # load csv file and check required fields
+        excerpt_info = self.load_csv(kwargs["csv"])
+        # load collections from the database
+        self.load_collections()
+        self.excerpt(excerpt_info)
+
+    def load_collections(self):
+        # load collections from the database and create
+        # a lookup based on collection names
+        self.collections = {c.name: c for c in Collection.objects.all()}
+
+    def excerpt(self, rows):
+        for row in rows:
+            # volume id in spreadsheet is our source id
+            source_id = row["Volume ID"]
+            # by default, assume we're modifying an existing record
+            created = False
+            # first look for an existing full work to convert to excerpt
+            digwork = DigitizedWork.objects.filter(
+                source_id=source_id,
+                item_type=DigitizedWork.FULL,
+                source=DigitizedWork.HATHI,
+            ).first()
+
+            # if there is no existing work to convert, create a new one
+            if not digwork:
+                digwork = DigitizedWork(source_id=source_id, source=DigitizedWork.HATHI)
+                # set created flag to true
+                created = True
+
+            # update all fields from spreadsheet data
+            # - required fields
+            digwork.item_type = self.item_type[row["Item Type"]]
+            digwork.title = row["Title"]
+            digwork.sort_title = row["Sort Title"]
+            digwork.book_journal = row["Book/Journal Title"]
+            # intspan requires commas; allow semicolons in input but convert to commas
+            digwork.pages_digital = row["Digital Page Range"].replace(";", ",")
+            digwork.record_id = row["Record ID"]
+            # - optional fields
+            digwork.author = row.get("Author", "")
+            digwork.pub_date = row.get("Publication Date", "")
+            digwork.pub_place = row.get("Publication Place", "")
+            digwork.publisher = row.get("Publisher", "")
+            digwork.enumcron = row.get("Enumcron", "")
+            digwork.pages_orig = row.get("Original Page Range", "")
+
+            digwork.notes = row.get("Notes", "")
+            digwork.public_notes = row.get("Public Notes", "")
+
+            # save to create or update
+            try:
+                digwork.save()
+            except intspan.ParseError as err:
+                self.stderr.write(
+                    self.style.WARNING("Error saving %s: %s" % (source_id, err))
+                )
+
+            # set collection membership based on spreadsheet data:
+            # collection is a single field with collection names delimited by semicolon
+            digwork_collections = [
+                self.collections[coll] for coll in row["Collection"].split(";")
+            ]
+            if digwork_collections:
+                digwork.collections.set(digwork_collections)
+
+            if created:
+                self.stats["created"] += 1
+                # log entry details
+                log_message = "Created via hathi_excerpt script"
+                log_action = ADDITION
+            else:
+                self.stats["updated"] += 1
+                log_message = "Converted to excerpt"
+                log_action = CHANGE
+
+            # create log entry to record what was done
+            LogEntry.objects.log_action(
+                user_id=self.script_user.pk,
+                content_type_id=self.digwork_contentype.pk,
+                object_id=digwork.pk,
+                object_repr=str(digwork),
+                change_message=log_message,
+                action_flag=log_action,
+            )
+
+    csv_required_fields = [
+        "Item Type",
+        "Volume ID",
+        "Title",
+        "Sort Title",
+        "Book/Journal Title",
+        "Digital Page Range",
+        "Collection",
+        "Record ID",
+    ]
+    # supported but not required:
+    # Author, Publication Date, Publication Place, Publisher, Enumcron, Original Page Range,
+    # Notes, Public Notes,
+
+    def load_csv(self, path):
+        """Load a CSV file with digworks to be excerpted."""
+        try:
+            with open(path, encoding="utf-8-sig") as csvfile:
+                csvreader = csv.DictReader(csvfile)
+                data = [
+                    row for row in csvreader if any(row.values())
+                ]  # skip blank rows
+        except FileNotFoundError:
+            raise CommandError("Error loading the specified CSV file: %s" % path)
+
+        csv_keys = set(data[0].keys())
+        csv_key_diff = set(self.csv_required_fields).difference(csv_keys)
+        # if any required fields are not present, error and quit
+        if csv_key_diff:
+            raise CommandError(
+                "Missing required fields in CSV file: %s" % ", ".join(csv_key_diff)
+            )
+        return data

--- a/ppa/archive/management/commands/hathi_excerpt.py
+++ b/ppa/archive/management/commands/hathi_excerpt.py
@@ -42,6 +42,12 @@ class Command(BaseCommand):
         self.load_collections()
         self.excerpt(excerpt_info)
 
+        self.stdout.write(
+            "\nExcerpted {excerpted:,d} existing records; created {created:,d} new excerpts. {error:,d} errors.".format_map(
+                self.stats
+            )
+        )
+
     def load_collections(self):
         # load collections from the database and create
         # a lookup based on collection names
@@ -93,6 +99,8 @@ class Command(BaseCommand):
                 self.stderr.write(
                     self.style.WARNING("Error saving %s: %s" % (source_id, err))
                 )
+                self.stats["error"] += 1
+                continue
 
             # set collection membership based on spreadsheet data:
             # collection is a single field with collection names delimited by semicolon
@@ -108,7 +116,7 @@ class Command(BaseCommand):
                 log_message = "Created via hathi_excerpt script"
                 log_action = ADDITION
             else:
-                self.stats["updated"] += 1
+                self.stats["excerpted"] += 1
                 log_message = "Converted to excerpt"
                 log_action = CHANGE
 

--- a/ppa/archive/management/commands/hathi_excerpt.py
+++ b/ppa/archive/management/commands/hathi_excerpt.py
@@ -119,14 +119,16 @@ class Command(BaseCommand):
             if digwork_collections:
                 digwork.collections.set(digwork_collections)
 
+        self.log_action(digwork, created)
+
         if created:
             self.stats["created"] += 1
         else:
             self.stats["excerpted"] += 1
 
-        self.log_action(digwork, created)
-
-        # TODO: make sure work & pages are updated in solr index
+        # Pages are automatically indexed due to page range check in save method.
+        # Index the new or updated work in solr
+        DigitizedWork.index_items([digwork])
 
     def log_action(self, digwork, created=True):
         """Create a log entry to document excerpting or creating the record.

--- a/ppa/archive/models.py
+++ b/ppa/archive/models.py
@@ -479,7 +479,7 @@ class DigitizedWork(TrackChangesModel, ModelIndexable):
                 self.page_count = self.count_pages()
                 # update index to remove all pages that are no longer in range
                 self.solr.update.delete_by_query(
-                    "source_id:(%s) AND item_type:page NOT order:(%s)"
+                    'source_id:"%s" AND item_type:page NOT order:(%s)'
                     % (self.source_id, " OR ".join(str(p) for p in self.page_span))
                 )
             # any page range change requires reindexing (potentially slow)

--- a/ppa/archive/tests/test_hathi_excerpt.py
+++ b/ppa/archive/tests/test_hathi_excerpt.py
@@ -1,0 +1,111 @@
+from unittest.mock import patch
+
+import pytest
+from django.contrib.admin.models import ADDITION, CHANGE, LogEntry
+from django.core.management.base import CommandError
+
+from ppa.archive.management.commands import hathi_excerpt
+from ppa.archive.models import Collection, DigitizedWork
+
+
+@pytest.mark.django_db
+class TestHathiExcerptCommand:
+    # @override_settings()
+    # def test_config_error(self):
+    #     cmd = gale_import.Command()
+    #     del settings.GALE_API_USERNAME
+    #     with pytest.raises(CommandError):
+    #         cmd.handle(ids=[], csv=None)
+
+    def test_load_collections(self):
+        # create test collections
+        collections = ["Grab bag", "Junk drawer"]
+        Collection.objects.bulk_create(
+            [Collection(name=value) for value in collections]
+        )
+        cmd = hathi_excerpt.Command()
+        cmd.load_collections()
+        # collection lookup should be populated
+        assert cmd.collections
+        for name in collections:
+            assert isinstance(cmd.collections[name], Collection)
+            assert cmd.collections[name].name == name
+
+    def test_load_csv(self, tmp_path):
+        cmd = hathi_excerpt.Command()
+        # simulate successful load and parse of CSV with all required fields
+        csvfile = tmp_path / "hathi_articles.csv"
+        csvfile.write_text(
+            "\n".join(
+                [
+                    "Item Type,Volume ID,Title,Sort Title,Book/Journal Title,Digital Page Range,Collection,Record ID",
+                    "Article,abc.12345,About Rhyme",
+                ]
+            )
+        )
+        data = cmd.load_csv(csvfile)
+        assert len(data) == 1
+        assert data[0]["Volume ID"] == "abc.12345"
+
+        # simulate successful load with missing fields
+        badcsvfile = tmp_path / "wrong.csv"
+        badcsvfile.write_text("\n".join(["Item Type,Volume ID,Title,", "foo,bar,baz"]))
+        with pytest.raises(CommandError) as err:
+            cmd.load_csv(badcsvfile)
+        assert "Missing required fields in CSV file" in str(err)
+        # error message should include the missing required fields; check a couple
+        assert "Sort Title" in str(err)
+        assert "Digital Page Range" in str(err)
+
+        # simulate invalid csv file
+        with pytest.raises(CommandError) as err:
+            badpath = "/bad/path/does/not/exist.csv"
+            cmd.load_csv(badpath)
+        assert f"Error loading the specified CSV file: {badpath}" in str(err)
+
+    @patch("ppa.archive.models.DigitizedWork.index_items")
+    def test_excerpt_existing_work(self, mock_index_items):
+        source_id = "abc:13245089"
+        # create test collections
+        coll1 = Collection.objects.create(name="One")
+        coll2 = Collection.objects.create(name="Two")
+        coll3 = Collection.objects.create(name="Three")
+        # create test work; default source = hathitrust, item type = full work
+        work = DigitizedWork.objects.create(
+            source_id=source_id, title="Saturday review of literature"
+        )
+        # associate with collection 1
+        work.collections.add(coll1)
+
+        cmd = hathi_excerpt.Command()
+        cmd.setup()
+
+        # test with required fields only
+        excerpt_info = {
+            "Volume ID": source_id,
+            "Item Type": "Article",
+            "Title": "Rhythm",
+            "Sort Title": "Rhythm",
+            "Book/Journal Title": "Saturday review of literature",
+            "Digital Page Range": "10-13",
+            "Record ID": "786544",
+            "Collection": "Two;Three",
+        }
+        cmd.excerpt(excerpt_info)
+        # inspect the newly-excerpted work; get a fresh copy from the db
+        excerpt = DigitizedWork.objects.get(pk=work.pk)
+        assert excerpt.item_type == DigitizedWork.ARTICLE
+        assert excerpt.title == excerpt_info["Title"]
+        assert excerpt.sort_title == excerpt_info["Sort Title"]
+        assert excerpt.book_journal == excerpt_info["Book/Journal Title"]
+        assert excerpt.pages_digital == excerpt_info["Digital Page Range"]
+        assert excerpt.record_id == excerpt_info["Record ID"]
+        # spreadsheet collection membership should replace any existing association
+        assert excerpt.collections.count() == 2
+        assert set(c.name for c in excerpt.collections.all()) == set(["Two", "Three"])
+
+        # check that log entry was created to document the change
+        log = LogEntry.objects.get(object_id=excerpt.pk)
+        assert log.action_flag == CHANGE
+        assert log.change_message == "Converted to excerpt"
+        assert log.user.username == "script"

--- a/ppa/archive/tests/test_hathi_excerpt.py
+++ b/ppa/archive/tests/test_hathi_excerpt.py
@@ -12,13 +12,6 @@ from ppa.archive.models import Collection, DigitizedWork
 
 @pytest.mark.django_db
 class TestHathiExcerptCommand:
-    # @override_settings()
-    # def test_config_error(self):
-    #     cmd = gale_import.Command()
-    #     del settings.GALE_API_USERNAME
-    #     with pytest.raises(CommandError):
-    #         cmd.handle(ids=[], csv=None)
-
     def test_load_collections(self):
         # create test collections
         collections = ["Grab bag", "Junk drawer"]
@@ -129,7 +122,8 @@ class TestHathiExcerptCommand:
         assert log.change_message == "Converted to excerpt"
         assert log.user.username == "script"
 
-    def test_excerpt_no_existing_work(self):
+    @patch("ppa.archive.models.DigitizedWork.index_items")
+    def test_excerpt_no_existing_work(self, mock_index_items):
         source_id = "abc.98763134"
         cmd = hathi_excerpt.Command()
         cmd.setup()
@@ -201,12 +195,8 @@ class TestHathiExcerptCommand:
         assert "Error saving %s" % source_id in error_output
         assert "start value should exceed stop (100-13)" in error_output
 
-    @patch("ppa.archive.management.commands.gale_import.Command.import_digitizedwork")
-    def test_call_command(self, mock_import_digwork):
-        call_command("gale_import", "1234")
-        assert mock_import_digwork.call_count == 1
-
-    def test_call_commmand(self, tmp_path):
+    @patch("ppa.archive.models.DigitizedWork.index_items")
+    def test_call_commmand(self, mock_index_items, tmp_path):
         stdout = StringIO()
         # create minimal valid CSV with all required fields
         csvfile = tmp_path / "hathi_articles.csv"

--- a/ppa/archive/tests/test_hathi_excerpt.py
+++ b/ppa/archive/tests/test_hathi_excerpt.py
@@ -1,3 +1,4 @@
+from io import StringIO
 from unittest.mock import patch
 
 import pytest
@@ -63,16 +64,20 @@ class TestHathiExcerptCommand:
             cmd.load_csv(badpath)
         assert f"Error loading the specified CSV file: {badpath}" in str(err)
 
-    @patch("ppa.archive.models.DigitizedWork.index_items")
+    @patch(
+        "ppa.archive.models.DigitizedWork.index_items"
+    )  # don't index on page range change
     def test_excerpt_existing_work(self, mock_index_items):
-        source_id = "abc:13245089"
+        source_id = "abc.13245089"
         # create test collections
         coll1 = Collection.objects.create(name="One")
         coll2 = Collection.objects.create(name="Two")
         coll3 = Collection.objects.create(name="Three")
         # create test work; default source = hathitrust, item type = full work
         work = DigitizedWork.objects.create(
-            source_id=source_id, title="Saturday review of literature"
+            source_id=source_id,
+            title="Saturday review of literature",
+            author="Else, Someone",
         )
         # associate with collection 1
         work.collections.add(coll1)
@@ -103,9 +108,94 @@ class TestHathiExcerptCommand:
         # spreadsheet collection membership should replace any existing association
         assert excerpt.collections.count() == 2
         assert set(c.name for c in excerpt.collections.all()) == set(["Two", "Three"])
+        # check that optional fields are blank
+        for field in [
+            "author",
+            "pub_place",
+            "publisher",
+            "enumcron",
+            "pages_orig",
+            "notes",
+            "public_notes",
+        ]:
+            assert getattr(excerpt, field) == ""
+        # publication date is an integer field, so unset should be None
+        assert excerpt.pub_date is None
 
         # check that log entry was created to document the change
         log = LogEntry.objects.get(object_id=excerpt.pk)
         assert log.action_flag == CHANGE
         assert log.change_message == "Converted to excerpt"
         assert log.user.username == "script"
+
+    def test_excerpt_no_existing_work(self):
+        source_id = "abc.98763134"
+        cmd = hathi_excerpt.Command()
+        cmd.setup()
+
+        # test with all fields
+        excerpt_info = {
+            "Volume ID": source_id,
+            "Item Type": "Excerpt",
+            "Title": "Rhythm",
+            "Sort Title": "Rhythm",
+            "Book/Journal Title": "Saturday review of literature",
+            "Digital Page Range": "10-13",
+            "Record ID": "23445677",
+            "Collection": "",
+            "Author": "Kroeger, A. E",
+            "Publication Date": 1872,
+            "Publication Place": "Baltimore, MD",
+            "Publisher": "Murdoch, Browne & Hill",
+            "Enumcron": "v.11",
+            "Original Page Range": "220-24",
+            "Notes": "Original biblography",
+            "Public Notes": "PERIODICAL",
+        }
+        cmd.excerpt(excerpt_info)
+        # chould create a NEW work
+        excerpt = DigitizedWork.objects.get(source_id=source_id)
+        assert excerpt.item_type == DigitizedWork.EXCERPT
+        assert excerpt.title == excerpt_info["Title"]
+        assert excerpt.sort_title == excerpt_info["Sort Title"]
+        assert excerpt.book_journal == excerpt_info["Book/Journal Title"]
+        assert excerpt.pages_digital == excerpt_info["Digital Page Range"]
+        assert excerpt.record_id == excerpt_info["Record ID"]
+        assert excerpt.author == excerpt_info["Author"]
+        assert excerpt.pub_date == excerpt_info["Publication Date"]
+        assert excerpt.pub_place == excerpt_info["Publication Place"]
+        assert excerpt.publisher == excerpt_info["Publisher"]
+        assert excerpt.enumcron == excerpt_info["Enumcron"]
+        assert excerpt.pages_orig == excerpt_info["Original Page Range"]
+        assert excerpt.notes == excerpt_info["Notes"]
+        assert excerpt.public_notes == excerpt_info["Public Notes"]
+
+        # check that log entry was created to document the change
+        log = LogEntry.objects.get(object_id=excerpt.pk)
+        assert log.action_flag == ADDITION
+        assert log.change_message == "Created via hathi_excerpt script"
+        assert log.user.username == "script"
+
+    def test_excerpt_parse_error(self):
+        source_id = "abc.123-456"
+        stderr = StringIO()
+        cmd = hathi_excerpt.Command(stderr=stderr)
+        cmd.setup()
+
+        # required fields only, with an invalid digital page range
+        excerpt_info = {
+            "Volume ID": source_id,
+            "Item Type": "Article",
+            "Title": "Rhythm",
+            "Sort Title": "Rhythm",
+            "Book/Journal Title": "Saturday review of literature",
+            "Digital Page Range": "100-13",
+            "Record ID": "786544",
+            "Collection": "",
+        }
+        cmd.excerpt(excerpt_info)
+        assert cmd.stats["error"] == 1
+        assert cmd.stats["created"] == 0
+        error_output = stderr.getvalue()
+        assert "Error saving %s" % source_id in error_output
+        assert "start value should exceed stop (100-13)" in error_output

--- a/ppa/archive/tests/test_models.py
+++ b/ppa/archive/tests/test_models.py
@@ -624,7 +624,7 @@ class TestDigitizedWork(TestCase):
             # should recalculate page count for this range
             assert work.page_count == 5
             mock_solr.update.delete_by_query.assert_called_with(
-                "source_id:(12345) AND item_type:page NOT order:(1 OR 2 OR 3 OR 4 OR 5)"
+                'source_id:"12345" AND item_type:page NOT order:(1 OR 2 OR 3 OR 4 OR 5)'
             )
 
     def test_clean(self):


### PR DESCRIPTION
manage command expects a csv with details for the excerpts and does the following:

- if a full work is found for the source id, the existing record is converted to an excerpt
- if not (i.e., multiple excerpts for the source and it's already been excerpted), create a new record; assumes that HathiTrust data is already available 
- whether new or existing record, populate all fields from the spreadsheet
- set collection membership
- create a log entry documenting creation or excerption
- summarize what was done

Currently the only error handling is for required fields in the csv and parse errors in the page range (which might be enough).