### PR TITLE
Revise hathi excerpt indexing and TrackChangesModel logic

### DIFF
--- a/ppa/archive/models.py
+++ b/ppa/archive/models.py
@@ -59,7 +59,8 @@ class TrackChangesModel(models.Model):
 
     def has_changed(self, field):
         """check if a field has been changed"""
-        return getattr(self, field) != self.__initial[field]
+        # Only consider the field changed if the object has been saved
+        return self.pk and getattr(self, field) != self.__initial[field]
 
     def initial_value(self, field):
         """return the initial value for a field"""
@@ -1039,7 +1040,8 @@ class Page(Indexable):
                 with ht_zip.open(pagefilename) as pagefile:
                     try:
                         yield {
-                            "id": "%s.%s" % (digwork.source_id, page.text_file.sequence),
+                            "id": "%s.%s"
+                            % (digwork.source_id, page.text_file.sequence),
                             "source_id": digwork.source_id,
                             "group_id_s": digwork_index_id,  # for grouping with work record
                             "content": pagefile.read().decode("utf-8"),


### PR DESCRIPTION
- `TrackChangesModel.has_changes()` now returns false for unsaved models
- re-ordered indexing changes in `DigitizedWork.save()` so that clearing index due to a changed group id happens _before_ indexing pages due to a changed page range
- adjusted `hathi_excerpt` script to count and index pages for newly created excerpts (previously happening on save due to the old `has_changes()` logic, but not logical that it should)