### PR TITLE
Allow the same page to belong to multiple excerpts

### DIFF
--- a/ppa/archive/models.py
+++ b/ppa/archive/models.py
@@ -1041,8 +1041,7 @@ class Page(Indexable):
                 with ht_zip.open(pagefilename) as pagefile:
                     try:
                         yield {
-                            "id": "%s.%s"
-                            % (digwork.source_id, page.text_file.sequence),
+                            "id": "%s.%s" % (digwork_index_id, page.text_file.sequence),
                             "source_id": digwork.source_id,
                             "group_id_s": digwork_index_id,  # for grouping with work record
                             "content": pagefile.read().decode("utf-8"),
@@ -1074,7 +1073,7 @@ class Page(Indexable):
             if page_span and i not in page_span:
                 continue
             yield {
-                "id": "%s.%s" % (digwork.source_id, page_number),
+                "id": "%s.%s" % (digwork_index_id, page_number),
                 "source_id": digwork.source_id,
                 "group_id_s": digwork_index_id,  # for grouping with work record
                 "content": page.get("ocrText"),  # some pages have no text

--- a/ppa/archive/tests/test_models.py
+++ b/ppa/archive/tests/test_models.py
@@ -979,6 +979,12 @@ class TestPage(TestCase):
             )
             page_data = list(Page.page_index_data(excerpt))
             assert len(page_data) == 2
+            # should use index id instead of source id as basis for solr id
+            # first page data (0) is index 1 in mets because excerpt starts at page 2
+            assert page_data[0]["id"] == "%s.%s" % (
+                excerpt.index_id(),
+                mets.structmap_pages[1].text_file.sequence,
+            )
 
             # not suppressed but no data
             mock_hathiobj.metsfile_path.side_effect = (


### PR DESCRIPTION
Use digwork index id for page base id instead of using digwork source id (which causes collisions when the same page belongs to more than one excerpt)