### PR TITLE
Use index/group id for unapi item id

### DIFF
--- a/ppa/archive/solr.py
+++ b/ppa/archive/solr.py
@@ -130,6 +130,7 @@ class ArchiveSearchQuerySet(AliasedSolrQuerySet):
         "source_url",
         "work_type_s",
         "book_journal_s",
+        "group_id_s",
     ]
     # aliases for any fields we want to rename for search and display
     # (must also be included in return_fields list)
@@ -139,6 +140,7 @@ class ArchiveSearchQuerySet(AliasedSolrQuerySet):
         "first_page_i": "first_page",
         "work_type_s": "work_type",
         "book_journal_s": "book_journal",
+        "group_id_s": "group_id",
     }
 
     keyword_query = None

--- a/ppa/archive/templates/archive/digitizedwork_detail.html
+++ b/ppa/archive/templates/archive/digitizedwork_detail.html
@@ -36,7 +36,7 @@
     <div class="work-type icon" aria-label="{{ object.get_item_type_display|lower }}"></div>
     {% endif %}
     <h1 class="header">{{ object.title }}</h1>
-    <abbr class="unapi-id" title="{{ object.source_id }}"></abbr>
+    <abbr class="unapi-id" title="{{ object.index_id }}"></abbr>
     <table class="metadata ui very basic table">
         <tbody>
             {% if object.subtitle %}

--- a/ppa/archive/templates/archive/snippets/search_result.html
+++ b/ppa/archive/templates/archive/snippets/search_result.html
@@ -1,7 +1,7 @@
 {% load static humanize %}
 
 <li class="item {{ item.work_type }}">
-    <abbr class="unapi-id" title="{{ item.source_id }}" aria-hidden="true"></abbr>
+    <abbr class="unapi-id" title="{{ item.group_id }}" aria-hidden="true"></abbr>
     <a href="{% if item.first_page %}{% url 'archive:detail' source_id=item.source_id start_page=item.first_page %}{% else %}{% url 'archive:detail' item.source_id %}{% endif %}{% if query %}?query={{ query }}{% endif %}" class="detail">
         <div class="brief-result container">
             <div class="title column">

--- a/ppa/archive/tests/test_views.py
+++ b/ppa/archive/tests/test_views.py
@@ -556,7 +556,7 @@ class TestDigitizedWorkListRequest(TestCase):
             # unapi identifier for each work
             self.assertContains(
                 response,
-                '<abbr class="unapi-id" title="%s"' % digwork.source_id,
+                '<abbr class="unapi-id" title="%s"' % digwork.index_id(),
                 msg_prefix="unapi id should be embedded for each work",
             )
 

--- a/ppa/unapi/tests.py
+++ b/ppa/unapi/tests.py
@@ -28,6 +28,10 @@ class TestUnAPIViews(TestCase):
         response = self.client.get(unapi_url, {"id": test_id, "format": "marc"})
         assert response.status_code == 404
 
+        # excerpt id should 404
+        response = self.client.get(unapi_url, {"id": test_id, "format": "marc"})
+        assert response.status_code == 404
+
         # valid id and format
         digwork = DigitizedWork.objects.first()
         with patch("ppa.unapi.views.get_object_or_404") as mock_getobj:
@@ -35,7 +39,7 @@ class TestUnAPIViews(TestCase):
             mock_getobj.return_value.get_metadata.return_value = mock_metadata_result
 
             response = self.client.get(
-                unapi_url, {"id": digwork.source_id, "format": "marc"}
+                unapi_url, {"id": digwork.index_id(), "format": "marc"}
             )
 
             mock_getobj.return_value.get_metadata.assert_called_with("marc")

--- a/ppa/unapi/tests.py
+++ b/ppa/unapi/tests.py
@@ -29,7 +29,9 @@ class TestUnAPIViews(TestCase):
         assert response.status_code == 404
 
         # excerpt id should 404
-        response = self.client.get(unapi_url, {"id": test_id, "format": "marc"})
+        response = self.client.get(
+            unapi_url, {"id": "%s-p43" % test_id, "format": "marc"}
+        )
         assert response.status_code == 404
 
         # valid id and format

--- a/ppa/unapi/views.py
+++ b/ppa/unapi/views.py
@@ -1,4 +1,5 @@
 from django.http import HttpResponse
+from django.http.response import Http404
 from django.shortcuts import get_object_or_404
 from django.views.generic.base import TemplateView
 
@@ -58,5 +59,12 @@ class UnAPIView(TemplateView):
 
     def get_metadata(self, item_id, data_format):
         """get item and requested metadata"""
+        # To distinguish excerpts, unapi id uses index/group id,
+        # which combines source id with first page number.
+        # We currently don't have MARC records for excerpts/articles,
+        # so just 404 for any excerpt ids.
+        if "-p" in item_id:
+            raise Http404
+        # for non-excerpt, index id is equivalent to source id
         item = get_object_or_404(DigitizedWork, source_id=item_id)
         return item.get_metadata(data_format)


### PR DESCRIPTION
excerpt unapi metadata requests will 404, but that's preferable to the current 500