### PR TITLE
Fix to progress bar when max_value set too low

### DIFF
--- a/ppa/archive/management/commands/generate_corpus.py
+++ b/ppa/archive/management/commands/generate_corpus.py
@@ -169,7 +169,11 @@ class SolrCorpus:
         self.doc_ids = self.page_counts.keys()
         self.doc_count = len(self.doc_ids)
         if pbar:
-            self.pbar = ProgressBar(redirect_stderr=True, max_value=self.doc_count)
+            self.pbar = ProgressBar(
+                redirect_stderr=True, 
+                max_value=self.doc_count, 
+                max_error=False
+            )
         else:
             self.pbar = NullBar()
 

--- a/ppa/archive/management/commands/hathi_import.py
+++ b/ppa/archive/management/commands/hathi_import.py
@@ -122,7 +122,9 @@ class Command(BaseCommand):
 
         if self.options["progress"]:
             progbar = progressbar.ProgressBar(
-                redirect_stdout=True, max_value=self.stats["total"]
+                redirect_stdout=True,
+                max_value=self.stats["total"],
+                max_error=False
             )
         else:
             progbar = None

--- a/ppa/archive/management/commands/index_pages.py
+++ b/ppa/archive/management/commands/index_pages.py
@@ -36,7 +36,11 @@ def process_index_queue(index_data_q, total_to_index, work_q):
     as a way of checking that all indexing is complete."""
 
     solr = SolrClient()
-    progbar = progressbar.ProgressBar(redirect_stdout=True, max_value=total_to_index)
+    progbar = progressbar.ProgressBar(
+        redirect_stdout=True, 
+        max_value=total_to_index,
+        max_error=False
+    )
     count = 0
     while True:
         try:

--- a/ppa/archive/tests/test_commands.py
+++ b/ppa/archive/tests/test_commands.py
@@ -209,7 +209,7 @@ class TestHathiImportCommand(TestCase):
             # request progress bar
             call_command("hathi_import", progress=1, verbosity=0, stdout=stdout)
             mockprogbar.ProgressBar.assert_called_with(
-                redirect_stdout=True, max_value=len(mock_htids)
+                redirect_stdout=True, max_value=len(mock_htids), max_error=False
             )
 
 
@@ -353,7 +353,7 @@ def test_process_index_queue(mock_solrclient, mock_progbar):
     mock_solrclient.return_value.update.index.assert_any_call(mockdata1)
     mock_solrclient.return_value.update.index.assert_any_call(mockdata2)
 
-    mock_progbar.ProgressBar.assert_called_with(redirect_stdout=True, max_value=total)
+    mock_progbar.ProgressBar.assert_called_with(redirect_stdout=True, max_value=total, max_error=False)
     progbar = mock_progbar.ProgressBar.return_value
     progbar.update.assert_any_call(4)
     progbar.update.assert_any_call(7)


### PR DESCRIPTION
This is a fix for https://github.com/Princeton-CDH/ppa-django/issues/482