### PR TITLE
Upgrading isort in precommit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         # Assumes that your shell's `python` command is linked to python3.6+
         language_version: python
   - repo: https://github.com/pycqa/isort
-    rev: 5.6.4
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]


### PR DESCRIPTION
I was getting this error for a while trying to use pre-commit on PPA: https://github.com/home-assistant/core/issues/86892

Upgrading isort here to fix it.