### PR TITLE
Manage command to update hathitrust page counts

### DIFF
--- a/ppa/archive/import_util.py
+++ b/ppa/archive/import_util.py
@@ -173,7 +173,8 @@ class HathiImporter(DigitizedWorkImporter):
             hathi.HathiItemForbidden: "Permission denied to download data.",
             RSYNC_ERROR: "Failed to sync data",
             # only saw this one on day, but this was what it was
-            JSONDecodeError: "HathiTrust catalog temporarily unavailable (malformed response).",
+            JSONDecodeError: "HathiTrust catalog temporarily unavailable "
+            + "(malformed response).",
         }
     )
 
@@ -256,7 +257,6 @@ class HathiImporter(DigitizedWorkImporter):
             # temporary preserve file for dev
             delete=False,
         ) as fp:
-
             file_paths = list(self.pairtree_paths.values())
             # sorting makes rsync more efficient
             file_paths.sort()
@@ -337,6 +337,9 @@ class HathiImporter(DigitizedWorkImporter):
             if digwork:
                 # populate page count
                 digwork.count_pages()
+                # save the page count to the database
+                if digwork.has_changed("page_count"):
+                    digwork.save()
                 self.imported_works.append(digwork)
 
             self.results[htid] = self.SUCCESS

--- a/ppa/archive/management/commands/update_hathi_pagecounts.py
+++ b/ppa/archive/management/commands/update_hathi_pagecounts.py
@@ -55,7 +55,8 @@ class Command(BaseCommand):
                 # recalculate page count from pairtree data
                 # NOTE: this method automatically saves if page count changes
                 digwork.page_count = digwork.count_pages()
-                if old_page_count != digwork.page_count:
+                if digwork.has_changed("page_count"):
+                    digwork.save()
                     stats["updated"] += 1
                     # create a log entry documenting page count change
                     LogEntry.objects.log_action(

--- a/ppa/archive/management/commands/update_hathi_pagecounts.py
+++ b/ppa/archive/management/commands/update_hathi_pagecounts.py
@@ -79,7 +79,7 @@ class Command(BaseCommand):
                 stats["missing_data"] += 1
 
         # report a summary of what was done
-        if verbosity >= self.v_normal:
+        if self.verbosity >= self.v_normal:
             self.stdout.write(
                 f"""Volumes with updated page count: {stats['updated']:,}
     Page count unchanged: {stats['unchanged']:,}

--- a/ppa/archive/management/commands/update_hathi_pagecounts.py
+++ b/ppa/archive/management/commands/update_hathi_pagecounts.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.contrib.admin.models import CHANGE, LogEntry
@@ -20,6 +18,7 @@ class Command(BaseCommand):
 
     #: normal verbosity level
     v_normal = 1
+    #: verbosity level for the current run; defaults to 1 / normal
     verbosity = v_normal
 
     def add_arguments(self, parser):
@@ -46,7 +45,7 @@ class Command(BaseCommand):
         if source_ids:
             hathi_vols = hathi_vols.filter(source_id__in=source_ids)
 
-        stats = {"updated":0, "unchanged":0, "missing_data":0}
+        stats = {"updated": 0, "unchanged": 0, "missing_data": 0}
 
         for digwork in hathi_vols:
             try:
@@ -82,7 +81,7 @@ class Command(BaseCommand):
         # report a summary of what was done
         if self.verbosity >= self.v_normal:
             self.stdout.write(
-                f"""Volumes with updated page count: {stats['updated']:,}
-    Page count unchanged: {stats['unchanged']:,}
-    Missing pairtree data: {stats['missing_data']:,}"""
+                f"Volumes with updated page count: {stats['updated']:,}"
+                + f"\n\tPage count unchanged: {stats['unchanged']:,}"
+                + f"\n\tMissing pairtree data: {stats['missing_data']:,}"
             )

--- a/ppa/archive/management/commands/update_hathi_pagecounts.py
+++ b/ppa/archive/management/commands/update_hathi_pagecounts.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **kwargs):
-        verbosity = kwargs.get("verbosity", self.v_normal)
+        self.verbosity = kwargs.get("verbosity", self.verbosity)
         source_ids = kwargs.get("source_ids", [])
         # page count does not affect solr indexing, so disconnect signal handler
         IndexableSignalHandler.disconnect()

--- a/ppa/archive/management/commands/update_hathi_pagecounts.py
+++ b/ppa/archive/management/commands/update_hathi_pagecounts.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
         if source_ids:
             hathi_vols = hathi_vols.filter(source_id__in=source_ids)
 
-        stats = defaultdict(int)
+        stats = {"updated":0, "unchanged":0, "missing_data":0}
 
         for digwork in hathi_vols:
             try:

--- a/ppa/archive/management/commands/update_hathi_pagecounts.py
+++ b/ppa/archive/management/commands/update_hathi_pagecounts.py
@@ -1,0 +1,87 @@
+from collections import defaultdict
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.contrib.admin.models import CHANGE, LogEntry
+from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
+from pairtree import storage_exceptions
+from parasolr.django.signals import IndexableSignalHandler
+
+from ppa.archive.models import DigitizedWork
+
+
+class Command(BaseCommand):
+    """Update database page counts for non-excerpted HathiTrust digitized items.
+    By default, runs on all non-excerpted, public HathiTrust items.
+    """
+
+    help = __doc__
+
+    #: normal verbosity level
+    v_normal = 1
+    verbosity = v_normal
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "source_ids", nargs="*", help="List of specific items to update (optional)"
+        )
+
+    def handle(self, *args, **kwargs):
+        verbosity = kwargs.get("verbosity", self.v_normal)
+        source_ids = kwargs.get("source_ids", [])
+        # page count does not affect solr indexing, so disconnect signal handler
+        IndexableSignalHandler.disconnect()
+
+        script_user = User.objects.get(username=settings.SCRIPT_USERNAME)
+        digwork_contentype = ContentType.objects.get_for_model(DigitizedWork)
+
+        # find all non-excerpted, non-suppressed hathi volumes
+        hathi_vols = DigitizedWork.objects.filter(
+            source=DigitizedWork.HATHI,
+            item_type=DigitizedWork.FULL,
+            status=DigitizedWork.PUBLIC,
+        )
+        # if source ids are specified, limit to those records only
+        if source_ids:
+            hathi_vols = hathi_vols.filter(source_id__in=source_ids)
+
+        stats = defaultdict(int)
+
+        for digwork in hathi_vols:
+            try:
+                # store the current page count
+                old_page_count = digwork.page_count
+                # recalculate page count from pairtree data
+                # NOTE: this method automatically saves if page count changes
+                digwork.page_count = digwork.count_pages()
+                if old_page_count != digwork.page_count:
+                    stats["updated"] += 1
+                    # create a log entry documenting page count change
+                    LogEntry.objects.log_action(
+                        user_id=script_user.pk,
+                        content_type_id=digwork_contentype.pk,
+                        object_id=digwork.pk,
+                        object_repr=str(digwork),
+                        change_message=f"Recalculated page count (was {old_page_count}, "
+                        + f"now {digwork.page_count})",
+                        action_flag=CHANGE,
+                    )
+
+                else:
+                    stats["unchanged"] += 1
+
+            except storage_exceptions.ObjectNotFoundException:
+                if verbosity >= self.v_normal:
+                    self.stderr.write(
+                        self.style.WARNING(f"Pairtree data for {digwork} not found")
+                    )
+                stats["missing_data"] += 1
+
+        # report a summary of what was done
+        if verbosity >= self.v_normal:
+            self.stdout.write(
+                f"""Volumes with updated page count: {stats['updated']:,}
+    Page count unchanged: {stats['unchanged']:,}
+    Missing pairtree data: {stats['missing_data']:,}"""
+            )

--- a/ppa/archive/management/commands/update_hathi_pagecounts.py
+++ b/ppa/archive/management/commands/update_hathi_pagecounts.py
@@ -72,7 +72,7 @@ class Command(BaseCommand):
                     stats["unchanged"] += 1
 
             except storage_exceptions.ObjectNotFoundException:
-                if verbosity >= self.v_normal:
+                if self.verbosity >= self.v_normal:
                     self.stderr.write(
                         self.style.WARNING(f"Pairtree data for {digwork} not found")
                     )

--- a/ppa/archive/models.py
+++ b/ppa/archive/models.py
@@ -252,7 +252,7 @@ class SignalHandlers:
                 logger.debug(
                     "cluster id has changed, reindexing %d works and %d pages",
                     works.count(),
-                    page_count["page_count"],
+                    page_count.get("page_count", 0),
                 )
                 DigitizedWork.index_items(works)
                 # reindex pages (this may be slow...)
@@ -907,7 +907,8 @@ class DigitizedWork(ModelIndexable, TrackChangesModel):
         number of files in the zipfile within the pairtree content (Hathi-specific).
         Raises :class:`pairtree.storage_exceptions.ObjectNotFoundException`
         if the data is not found in the pairtree storage. Returns page count
-        found; saves the object if the count changes."""
+        found; updates the `page_count` attribute on the current instance,
+        but does NOT save the object."""
 
         # if this item has a page span defined, calculate number of pages
         # based on the number of pages across all spans
@@ -941,11 +942,9 @@ class DigitizedWork(ModelIndexable, TrackChangesModel):
         # NOTE: could also count pages via mets file, but that's slower
         # than counting via zipfile name list
 
-        # store page count in the database if changed
-        if self.page_count != page_count:
-            self.page_count = page_count
-            self.save()
-
+        # update page count on the instance, but don't save changes
+        self.page_count = page_count
+        # return the total
         return page_count
 
     @property

--- a/ppa/archive/tests/test_models.py
+++ b/ppa/archive/tests/test_models.py
@@ -633,8 +633,9 @@ class TestDigitizedWork(TestCase):
 
         # return total and digitized work page counts updated
         assert page_count == 2
-        digwork = DigitizedWork.objects.get(source_id=digwork.source_id)
-        assert digwork.page_count == 2
+        # does NOT save automatically
+        db_digwork = DigitizedWork.objects.get(source_id=digwork.source_id)
+        assert db_digwork.page_count is None
 
         # should ignore non-text files
         page_files = ["0001.txt", "00002.txt", "00001.jp2", "00002.jp2"]


### PR DESCRIPTION
Adds a new manage command to update page counts for non-excerpted HathiTrust works.

Reports on what was done, and creates log entries so an admin will be able to see the change.

I haven't created any unit tests since I'm not sure we will actually want to keep the script in this form - it seems that there may be multiple things that we'll want to do when we updated hathitrust content (rsync, check excerpts, recalculate pages...)

related to #567 

Currently the `count_pages` method saves the model if changed (unless it's an excerpt!); based on the difficulties I had tripping over that here and some other related investigations, I'm planning to refactor that so it does not save and make sure the calling code handles saving when appropriate - but this can be reviewed independent of that refactor.

