### PR TITLE
Improve hathi_rsync manage command so it can sync and report on all hathi content

### DIFF
--- a/ppa/archive/management/commands/hathi_rsync.py
+++ b/ppa/archive/management/commands/hathi_rsync.py
@@ -1,4 +1,8 @@
-from django.core.management.base import BaseCommand, CommandError
+import os.path
+from datetime import datetime
+
+from django.core.management.base import BaseCommand
+from pairtree import path2id
 
 from ppa.archive.import_util import HathiImporter
 from ppa.archive.models import DigitizedWork
@@ -26,22 +30,64 @@ class Command(BaseCommand):
         # use ids specified via command line when present
         htids = kwargs.get("htids", [])
 
-        # if hathi ids not specified via command line,
-        # get all non-suppressed hathi records
-        if not htids:
-            htids = DigitizedWork.objects.filter(
-                status=DigitizedWork.PUBLIC, source=DigitizedWork.HATHI
-            ).values_list("source_id", flat=True)
-
-        # NOTE: if htid is specified, should we verify that it's
-        # in the db and not suppressed? (should import first if not)
-
-        self.stdout.write(
-            self.style.SUCCESS("Synchronizing data for %d records" % len(htids))
+        # by default, sync data for all non-suppressed hathi source ids
+        digworks = DigitizedWork.objects.filter(
+            status=DigitizedWork.PUBLIC, source=DigitizedWork.HATHI
         )
-        # even if verbosity is zero we want an output file
+
+        # if htids are specified via parameter, use them to filter
+        # the queryset, to ensure we only sync records that are
+        # in the database and not suppressed
+        if htids:
+            digworks = digworks.filter(source_id__in=htids)
+        # NOTE: report here on any skipped ids?
+
+        # generate a list of unique source ids from the queryset
+        hathi_ids = digworks.values_list("source_id", flat=True).distinct()
+        self.stdout.write("Synchronizing data for %d records" % len(hathi_ids))
+        # we always want itemized rsync output, so we can report
+        # on which volumes were updated
         htimporter = HathiImporter(
-            source_ids=htids, rsync_output=self.verbosity or True
+            source_ids=hathi_ids, rsync_output=True, output_dir="/tmp"
         )
         logfile = htimporter.rsync_data()
-        self.stdout.write(self.style.SUCCESS("rsync output is in %s" % logfile))
+
+        # read the rsync itemized output to identify records where file
+        # sizes changed
+        updated_ids = set()
+        with open(logfile) as rsync_output:
+            for line in rsync_output:
+                # if a line indicates that a file was updated due
+                # to a change in size, use the path to determine the hathi id
+                if " >f.s" in line:
+                    # rsync itemized output is white-space delimited;
+                    # last element is the filename that was updated
+                    filename = line.rsplit()[-1].strip()
+                    # we only care about zip files and mets.xml files
+                    if not filename.endswith(".zip") and not filename.endswith(".xml"):
+                        continue
+                    # reconstruct the hathi id from the filepath
+                    ht_prefix, pairtree_dir = filename.split("/pairtree_root/")
+                    # get the directory one level up from the updated file
+                    pairtree_id = os.path.dirname(os.path.dirname(pairtree_dir))
+                    # use pairtree to determine the id based on the path
+                    # (handles special characters like those used in ARKs)
+                    htid = f"{ht_prefix}.{path2id(pairtree_id)}"
+                    updated_ids.add(htid)
+
+        # should this behavior only be when updating all?
+        # if specific htids are specified on the command line, maybe report on them only?
+        if updated_ids:
+            outfilename = "ppa_rsync_updated_htids_%s.txt" % datetime.now().strftime(
+                "%Y%m%d-%H%M%S"
+            )
+            with open(outfilename, "w") as outfile:
+                outfile.write("\n".join(sorted(updated_ids)))
+            success_msg = (
+                f"File sizes changed for {len(updated_ids)} hathi ids; "
+                + f"full list in {outfilename}"
+            )
+        else:
+            success_msg = "rsync completed; no changes to report"
+
+        self.stdout.write(self.style.SUCCESS(success_msg))


### PR DESCRIPTION
relates most directly to #428 but also relevant to most of the rsync items aggregated by #598

changes in this PR:
- improves the existing `hathi_rsync` command so it can be run to sync content for all non-suppressed hathi records in PPA
  - fix importer rsync logging so it does not output all source ids when syncing more than a handful of records
  - add an optional output dir for rsync itemized output
- parse rsync itemized output to identify paths that were updated due to a change; convert path to htid and generate a report of all updated htids

I have tested this locally using an rsync from staging server to my local development server and it seems to be working for the scenarios I've tried.

I haven't worked on unit tests related to this change yet, in part because I think this may not be the final form we want - in part because I think this will be one piece in a larger pipeline of updates triggered by content being updated through rsync.

My rsync output parsing does not do any checking for deleted files; that's a different scenario than we're currently concerned about, but we might want to think about that at some point. (... and looks like I made some notes on that on #428)