### PR TITLE
New manage command to check HathiTrust excerpt page ranges

### DIFF
--- a/ppa/archive/hathi.py
+++ b/ppa/archive/hathi.py
@@ -189,7 +189,7 @@ class StructMapPage(_METS):
          <METS:fptr FILEID="IMG00000001"/>
        <METS:file SIZE="1003" ID="HTML00000496" MIMETYPE="text/html" CREATED="2017-03-20T10:40:21Z"
          CHECKSUM="f0a326c10b2a6dc9ae5e3ede261c9897" SEQ="00000496" CHECKSUMTYPE="MD5">
-    """
+    """  # noqa: E501
 
     @cached_property
     def display_label(self):
@@ -244,9 +244,9 @@ class HathiObject:
 
     # Pairtree version statement usd by pairtree package
     pairtree_version_stmt = (
-        "This directory conforms to Pairtree Version 0.1. Updated spec: " +
-        "http://www.cdlib.org/inside/diglib/pairtree/pairtreespec.html"
-        )
+        "This directory conforms to Pairtree Version 0.1. Updated spec: "
+        + "http://www.cdlib.org/inside/diglib/pairtree/pairtreespec.html"
+    )
 
     def __init__(self, hathi_id):
         # HathiTrust record id
@@ -264,13 +264,13 @@ class HathiObject:
         """Initialize a pairtree client for the pairtree datastore this
         object belongs to, based on its HathiTrust record id."""
         store_dir = os.path.join(settings.HATHI_DATA, self.lib_id)
-        
+
         # Check if store_dir exists, check if pairtree files exist
         if os.path.isdir(store_dir):
             # Check if "pairtree_prefix" file exists. If not, create it.
             pairtree_prefix_fn = os.path.join(store_dir, "pairtree_prefix")
             if not os.path.isfile(pairtree_prefix_fn):
-                with open(pairtree_prefix_fn, mode='w') as writer:
+                with open(pairtree_prefix_fn, mode="w") as writer:
                     writer.write(self.pairtree_prefix)
             # Check if "pairtree_version0_1" file exists. If not, create it.
             # Note: Mimicking paitree packages behavior. File contents are not
@@ -320,10 +320,12 @@ class HathiObject:
         parts = pairtree_obj.list_parts(self.content_dir)
         # find the first zipfile in the list (should only be one)
         filepaths = [part for part in parts if part.endswith(ext)]
-        if not filepaths: 
+        if not filepaths:
             # An error has occurred -- there is no zip file here in parts
             raise storage_exceptions.PartNotFoundException
-        return os.path.join(pairtree_obj.id_to_dirpath(), self.content_dir, filepaths[0])
+        return os.path.join(
+            pairtree_obj.id_to_dirpath(), self.content_dir, filepaths[0]
+        )
 
     def zipfile_path(self, ptree_client=None):
         """path to zipfile within the hathi contents for this work"""
@@ -332,3 +334,15 @@ class HathiObject:
     def metsfile_path(self, ptree_client=None):
         """path to mets xml file within the hathi contents for this work"""
         return self._content_path(".mets.xml", ptree_client=ptree_client)
+
+    def mets_xml(self) -> MinimalMETS:
+        """load METS xml file from pairtree and initialize as an instance
+        of :class:`MinimalMETS`
+
+        :rtype: :class:`MinimalMETS`
+        :raises: :class:`storage_exceptions.ObjectNotFoundException` if the
+            object is not found in pairtree storage
+        :raises: :class:`storage_exceptions.PartNotFoundException` if the
+            mets.xml flie is not found in pairtree storage for this object
+        """
+        return xmlmap.load_xmlobject_from_file(self.metsfile_path(), MinimalMETS)

--- a/ppa/archive/management/commands/check_hathi_excerpts.py
+++ b/ppa/archive/management/commands/check_hathi_excerpts.py
@@ -1,0 +1,128 @@
+import csv
+
+from django.core.management.base import BaseCommand
+from pairtree import storage_exceptions
+
+from intspan import intspan
+
+from ppa.archive.models import DigitizedWork
+from ppa.archive.templatetags.ppa_tags import hathi_page_url
+
+
+class Command(BaseCommand):
+    """Check page alignment for excerpted HathiTrust digitized items."""
+
+    help = __doc__
+
+    #: normal verbosity level
+    v_normal = 1
+    #: verbosity level for the current run; defaults to 1 / normal
+    verbosity = v_normal
+
+    def handle(self, *args, **kwargs):
+        self.verbosity = kwargs.get("verbosity", self.verbosity)
+
+        # find all excerpted, non-suppressed hathi volumes
+        hathi_vols = DigitizedWork.objects.filter(
+            source=DigitizedWork.HATHI,
+            status=DigitizedWork.PUBLIC,
+        ).exclude(item_type=DigitizedWork.FULL)
+
+        output_fields = [
+            "source_id",
+            "unique_id",
+            "pages_orig",
+            "pages_digital",
+            "orig_label_match",
+            "pages_digital_corrected",
+            "old_hathi_start",
+            "new_hathi_start",
+            "notes",
+        ]
+
+        with open("ppa-excerpt-pagecheck.csv", "w") as csvfile:
+            csvwriter = csv.DictWriter(csvfile, fieldnames=output_fields)
+            csvwriter.writeheader()
+
+            for digwork in hathi_vols:
+                info = {
+                    "source_id": digwork.source_id,
+                    # source id + first page (currently digital, will be switching to original)
+                    "unique_id": digwork.index_id(),
+                    "pages_orig": digwork.pages_orig,
+                    "pages_digital": digwork.pages_digital,
+                    "old_hathi_start": hathi_page_url(
+                        digwork.source_id, digwork.first_page_digital()
+                    ),
+                }
+                # NOTE: mets loading copied from hathi_page_index_data method
+                # worth movint to a method on the hathi object?
+                try:
+                    mmets = digwork.hathi.mets_xml()
+                except storage_exceptions.ObjectNotFoundException:
+                    # document the error in the output csv, stop processing
+                    info["notes"] = "pairtree data not found"
+                    csvwriter.writerow(info)
+                    continue
+                except storage_exceptions.PartNotFoundException:
+                    info["notes"] = "error loading mets file (part not found)"
+                    csvwriter.writerow(info)
+                    continue
+
+                # make a list of page labels and order from mets structmap
+                page_info = [
+                    {"order": page.order, "label": page.orderlabel}
+                    # also have access to label (@LABEL vs @ORDERLABEL)
+                    for page in mmets.structmap_pages
+                ]
+
+                # use digital page range to get the first page in the mets
+                # that would be included with current digital range (1-based index)
+                try:
+                    excerpt_first_page = page_info[digwork.first_page_digital() + 1]
+                except IndexError:
+                    if digwork.first_page_digital() >= len(page_info):
+                        excerpt_first_page[-1]
+                        info["notes"] = "digital page out of range; trying last page"
+
+                # some mets records don't have labels
+                # or, label attribute may be present but empty
+                # do we need to check if all pages are missing labels?
+                if (
+                    excerpt_first_page["label"] is None
+                    or excerpt_first_page["label"].strip() == ""
+                ):
+                    # add a note that mets doesn't have labels, stop processing
+                    info["notes"] = "no page label in METS structmap"
+                    csvwriter.writerow(info)
+                    continue
+
+                # check if METS page label for the first page in range
+                # matches the desired first original page
+                if excerpt_first_page["label"] != str(digwork.first_page_original()):
+                    info["orig_label_match"] = "N"
+                    # if they don't match, can we calculate the offset?
+                    # (only works for numeric page labels)
+                    try:
+                        diff = int(digwork.first_page_original()) - int(
+                            excerpt_first_page["label"]
+                        )
+                        # calculate the expected new digital page range
+                        # - apply the difference to each number in range,
+                        #   since we do have some discontinuous ranges
+                        # - convert back to intspan so we can output in
+                        #   page range format (1-3 or 1-3,5)
+                        new_range = [n + diff for n in digwork.page_span]
+                        info["pages_digital_corrected"] = intspan(new_range)
+                        info["new_hathi_start"] = hathi_page_url(
+                            digwork.source_id, new_range[0]
+                        )
+                    except ValueError as err:
+                        info["notes"] = "could not calculate page offset (%s)" % err
+
+                else:
+                    info["orig_label_match"] = "Y"
+                    info["notes"] = "page labels match"
+
+                # either way, write out the info
+                csvwriter.writerow(info)

--- a/ppa/archive/tests/test_models.py
+++ b/ppa/archive/tests/test_models.py
@@ -778,6 +778,19 @@ class TestDigitizedWork(TestCase):
             work.clean_fields()
         assert "start value should exceed stop (355-35)" in str(err)
 
+    def test_first_page_digital(self):
+        assert DigitizedWork(pages_digital="133-135").first_page_digital() == 133
+
+    def test_first_page_original(self):
+        # citation-style page range (second number is incomplete)
+        assert DigitizedWork(pages_orig="133-5").first_page_original() == "133"
+        # single page number
+        assert DigitizedWork(pages_orig="133").first_page_original() == "133"
+        # discontinuous page range
+        assert DigitizedWork(pages_orig="133, 134").first_page_original() == "133"
+        # roman numreals
+        assert DigitizedWork(pages_orig="iii-xiv").first_page_original() == "iii"
+
     def test_is_suppressed(self):
         work = DigitizedWork(source_id="chi.79279237")
         assert not work.is_suppressed


### PR DESCRIPTION
ref #560 

uses METS structmap page labels to compare original page numbers and determine if digital page numbers need to be adjusted; generates a CSV report of the proposed adjustments or any errors in attempting to determine them