### PR TITLE
Admin excerpt source links, first page validation, hathitrust page urls

### DIFF
--- a/ppa/archive/admin.py
+++ b/ppa/archive/admin.py
@@ -184,8 +184,10 @@ class DigitizedWorkAdmin(ExportActionMixin, ExportMixin, admin.ModelAdmin):
         # hathi/gale excerpt links should include first page
         if obj.pages_digital:
             if obj.source == DigitizedWork.HATHI:
-                source_url = hathi_page_url(obj.source_url, obj.first_page_digital())
+                # hathi page url method requires source id
+                source_url = hathi_page_url(obj.source_id, obj.first_page_digital())
             if obj.source == DigitizedWork.GALE:
+                # gale page url method requires source url
                 source_url = gale_page_url(obj.source_url, obj.first_page_digital())
         return mark_safe(
             '<a href="%s" target="_blank">%s</a>' % (source_url, obj.source_id)

--- a/ppa/archive/models.py
+++ b/ppa/archive/models.py
@@ -672,7 +672,7 @@ class DigitizedWork(ModelIndexable, TrackChangesModel):
             ).by_first_page_orig(first_page)
             # if this record has already been saved, exclude it when checking
             if self.pk:
-                other_excerpts.exclude(pk=self.pk)
+                other_excerpts = other_excerpts.exclude(pk=self.pk)
             if other_excerpts.exists():
                 raise ValidationError(
                     {

--- a/ppa/archive/templatetags/ppa_tags.py
+++ b/ppa/archive/templatetags/ppa_tags.py
@@ -71,7 +71,9 @@ def hathi_page_url(item_id, order):
 
         {% page_url item_id page.order %}
     """
-    return "{}/pt?id={};view=1up;seq={}".format(HATHI_BASE_URL, item_id, order)
+    return mark_safe(
+        "{}/pt?id={}&view=1up&seq={}".format(HATHI_BASE_URL, item_id, order)
+    )
 
 
 @register.simple_tag

--- a/ppa/archive/tests/test_admin.py
+++ b/ppa/archive/tests/test_admin.py
@@ -58,6 +58,8 @@ class TestDigitizedWorkAdmin(TestCase):
         snippet = digadmin.source_link(digwork)
         assert digwork.source_id in snippet
         assert "seq=22" in snippet
+        # hathi url is based on source id, not source url
+        assert digwork.source_url not in snippet
         # Gale
         digwork.source = DigitizedWork.GALE
         snippet = digadmin.source_link(digwork)

--- a/ppa/archive/tests/test_models.py
+++ b/ppa/archive/tests/test_models.py
@@ -805,9 +805,14 @@ class TestDigitizedWork(TestCase):
 
     @patch("ppa.archive.models.DigitizedWork.index_items")
     def test_clean_unique_first_page(self, mock_index_items):
-        DigitizedWork.objects.create(
+        digwork = DigitizedWork.objects.create(
             source_id="chi.79279237", pages_orig="233-244", pages_digital="200-210"
         )
+        # save with unrelated change; should not trigger validation error
+        digwork.pages_digital = "201-210"
+        digwork.save()
+        digwork.clean()
+
         # first original page matches even though range is distinct; unsaved
         work2 = DigitizedWork(source_id="chi.79279237", pages_orig="233-240")
         with pytest.raises(

--- a/ppa/archive/tests/test_templatetags.py
+++ b/ppa/archive/tests/test_templatetags.py
@@ -73,7 +73,7 @@ def test_hathi_page_url():
     order = 50
     hathi_url = hathi_page_url(item_id, order)
     assert hathi_url.startswith("%s/pt" % HATHI_BASE_URL)
-    assert hathi_url.endswith("?id=%s;view=1up;seq=%s" % (item_id, order))
+    assert hathi_url.endswith("?id=%s&view=1up&seq=%s" % (item_id, order))
 
 
 def test_gale_page_url():


### PR DESCRIPTION
- correct admin source link for hathitrust excerpts
- correct exclusion for current object when validating first page is unique for source
- update hathitrust page url to use ampersands instead of semicolons for url parameters