### PR TITLE
Page indexing refactor

### DIFF
--- a/ppa/archive/gale.py
+++ b/ppa/archive/gale.py
@@ -181,6 +181,32 @@ class GaleAPI:
         if response:
             return response.json()
 
+    def get_item_pages(self, item_id, gale_record=None):
+        """Return a generator of page content for the specified digitized work
+        from the Gale API. Takes an optional gale_record
+        parameter (item record as returned by Gale API), to avoid
+        making an extra API call if data is already available."""
+        if gale_record is None:
+            gale_record = self.get_item(item_id)
+
+        # iterate through the pages in the response
+        for page in gale_record["pageResponse"]["pages"]:
+            page_number = page["pageNumber"]
+            # page label (original page number) should be set in folioNumber,
+            # but is not set for all volumes; fallback to page number
+            # converted to integer to drop leading zeroes
+            page_label = page.get("folioNumber", int(page_number))
+            info = {
+                "id": page_number,
+                "content": page.get("ocrText"),  # some pages have no text
+                "label": page_label,
+                # image id needed for thumbnail url; use solr dynamic field
+                "image_id_s": page["image"]["id"],
+                # index image url since we will need it when Gale API changes
+                "image_url_s": page["image"]["url"],
+            }
+            yield info
+
 
 # MARC records needed for import and metadata are stored in a local pairtree.
 # currently used for Gale/ECCO content

--- a/ppa/archive/gale.py
+++ b/ppa/archive/gale.py
@@ -197,13 +197,14 @@ class GaleAPI:
             # converted to integer to drop leading zeroes
             page_label = page.get("folioNumber", int(page_number))
             info = {
-                "id": page_number,
+                "page_id": page_number,
                 "content": page.get("ocrText"),  # some pages have no text
                 "label": page_label,
                 # image id needed for thumbnail url; use solr dynamic field
                 "image_id_s": page["image"]["id"],
                 # index image url since we will need it when Gale API changes
-                "image_url_s": page["image"]["url"],
+                # (expect to be present in Gale API; may not be present in unit tests)
+                "image_url_s": page["image"].get("url"),
             }
             yield info
 

--- a/ppa/archive/import_util.py
+++ b/ppa/archive/import_util.py
@@ -522,7 +522,7 @@ class GaleImporter(DigitizedWorkImporter):
 
         # item record used for import includes page metadata;
         # for efficiency, index pages at import time with the same api response
-        DigitizedWork.index_items(Page.gale_page_index_data(digwork, item_record))
+        DigitizedWork.index_items(Page.page_index_data(digwork, item_record))
 
         # return the newly created record
         return digwork

--- a/ppa/archive/models.py
+++ b/ppa/archive/models.py
@@ -1228,6 +1228,10 @@ class Page(Indexable):
 
         # get page span from digitized work, to handle excerpts
         page_span = digwork.page_span
+        # if indexing an excerpt, determine highest page to be indexed
+        max_page = None
+        if page_span:
+            max_page = max(page_span)
         # index id is used to group work and pages; also fallback for cluster id
         # for works that are not part of a cluster
         digwork_index_id = digwork.index_id()
@@ -1236,6 +1240,13 @@ class Page(Indexable):
         for i, page_info in enumerate(pages, 1):
             # page info is expected to contain page_id, content, order, label
             # may contain tags, image id, image url
+
+            # if indexing a page range, stop iterating once we are
+            # past the highest page in range and close the generator
+            if max_page and i > max_page:
+                pages.close()
+                # NOTE: on OSX, when used with multiproc index_pages, requires
+                # envionment variable OBJC_DISABLE_INITIALIZE_FORK_SAFETY="YES"
 
             # if the document has a page range defined, skip any pages not in range
             if page_span and i not in page_span:

--- a/ppa/archive/tests/test_import_util.py
+++ b/ppa/archive/tests/test_import_util.py
@@ -344,6 +344,8 @@ class TestGaleImporter(TestCase):
         # should set status in results dict for reporting
         assert importer.results[test_id] == not_found_error
 
+    # username is required to init GaleAPI class, but API is not actually used
+    @override_settings(GALE_API_USERNAME="unused")
     @patch("ppa.archive.import_util.get_marc_record")
     @patch("ppa.archive.import_util.GaleAPI")
     def test_import_digitizedwork_success(self, mock_gale_api, mock_get_marc_record):

--- a/ppa/archive/tests/test_models.py
+++ b/ppa/archive/tests/test_models.py
@@ -13,7 +13,7 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db.models.query import QuerySet
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 from pairtree import pairtree_client, pairtree_path, storage_exceptions
 from parasolr.django.indexing import ModelIndexable
@@ -1140,6 +1140,8 @@ class TestPage(TestCase):
         nonhathi_work = DigitizedWork(source=DigitizedWork.OTHER)
         assert not list(Page.page_index_data(nonhathi_work))
 
+    # username is required to init GaleAPI class, but API is not actually used
+    @override_settings(GALE_API_USERNAME="unused")
     @patch.object(gale.GaleAPI, "get_item")
     def test_gale_page_index_data(self, mock_gale_get_item):
         gale_work = DigitizedWork(source=DigitizedWork.GALE, source_id="CW123456")


### PR DESCRIPTION
This refactors the code for page indexing to setup work for the EEBO import.

Previously there were separate methods for Gale and HathiTrust page index data, with substantial overlap in common logic. This refactor implements source-specific page data generators, which are then consumed and updated with the common logic (like excerpt handling) and fields needed for all page records.

Also adds an efficiency improvement: when indexing pages for an excerpt, we don't need to keep iterating once we've got the data for the range we care about.

I also updated one test that has caused problems before, where we had some hard-coded solr page index data. Now it takes advantage of the common page field logic, so if page indexing logic or fields change it will automatically get those updates.
