### PR TITLE
Revise eebo-tcp page text logic to put notes after main page text

### DIFF
--- a/ppa/archive/eebo_tcp.py
+++ b/ppa/archive/eebo_tcp.py
@@ -28,6 +28,7 @@ class Page(xmlmap.XmlObject):
     # use following axis to find all text nodes following this page beginning
     text_contents = xmlmap.StringListField("following::text()")
     # count following notes as a quick check to bail out of note detection logic
+    # (can't use eulxml boolean field here because it assumes string values for true/false)
     has_notes = xmlmap.IntegerField("count(following::NOTE)")
 
     def __repr__(self):
@@ -94,10 +95,8 @@ class Page(xmlmap.XmlObject):
             if within_note is not None:
                 # is this the first text in this note?
                 within_note.xpath(".//text()")
-                # print(f"first note text = {first_text}")
                 is_first_text = within_note.xpath(".//text()")[0] == str(text)
                 if is_first_text:
-                    # print(f"hit first note text {text}")
                     # if this is the first text for this note,
                     # add a marker inline with the text AND to the note
                     note_mark = within_note.get("N", self.get_note_mark(note_index))

--- a/ppa/archive/eebo_tcp.py
+++ b/ppa/archive/eebo_tcp.py
@@ -34,20 +34,19 @@ class Page(xmlmap.XmlObject):
     def __repr__(self):
         return f"<Page {self.number or '-'} ({self.section_type})>"
 
-    note_markers = [
-        "*",
-        "†",
-        "‡",
-        "§",
-        "**",
-        "††",
-        "‡‡",
-        "§§",
-        "***",
-        "†††",
-        "‡‡‡",
-        "§§§",
-    ]
+    # footnote indicators
+    note_marks = ["*", "†", "‡", "§"]
+    num_note_marks = len(note_marks)
+
+    def get_note_mark(self, i):
+        """Generate a note marker based on note index and :attr:`note_marks`;
+        symbols are used in order and then doubled, tripled, etc as needed."""
+
+        # use modulo to map to the list of available marks
+        mark_index = i % self.num_note_marks
+        # use division to determine how many times to repeat the mark
+        repeat = int(i / self.num_note_marks) + 1
+        return self.note_marks[mark_index] * repeat
 
     def text_inside_note(self, text):
         """check if a text element occurs within a NOTE element; if so,
@@ -108,10 +107,10 @@ class Page(xmlmap.XmlObject):
                 # index equals length, start a new note at the end of the list of notes
                 if len(notes) == note_index:
                     # some note tags have an N attribute; use if present
-                    # otherwise, use marker from our list based on sequence
-                    note_marker = within_note.get("N", self.note_markers[note_index])
-                    yield note_marker
-                    notes.append(f"\n{note_marker} ")
+                    # otherwise, use a note mark from our list of symbols
+                    note_mark = within_note.get("N", self.get_note_mark(note_index))
+                    yield note_mark
+                    notes.append(f"\n{note_mark} ")
 
                 # add text to the appropriate note
                 notes[note_index] = f"{notes[note_index]}{text}"

--- a/ppa/archive/eebo_tcp.py
+++ b/ppa/archive/eebo_tcp.py
@@ -56,17 +56,16 @@ class Page(xmlmap.XmlObject):
         if not self.notes:
             return None
 
-        within_note = None
         # check if this text is directly inside a note tag
+        within_note = None
+        # check if this is normal text directly inside a note tag
         parent = text.getparent()
-        if parent.tag == "NOTE" and not text.is_tail:
+        if parent.tag == "NOTE" and text.is_text:
             within_note = parent
-        # otherwise, check if text is nested under a note tag
+        # otherwise, check if text is nested somewhere under a note tag
         else:
-            for ancestor in parent.iterancestors():
-                if ancestor.tag == "NOTE":
-                    within_note = ancestor
-                    break
+            note_ancestors = parent.xpath("ancestor::NOTE[1]")
+            within_note = note_ancestors[0] if note_ancestors else None
 
         return within_note
 
@@ -100,7 +99,7 @@ class Page(xmlmap.XmlObject):
             # determine if this text falls inside a note tag
             within_note = self.text_inside_note(text)
             if within_note is not None:
-                # and if so, which one
+                # if text is inside a note, determine which one
                 note_index = self.note_index(within_note)
                 # if this is the first text for this note,
                 # add a marker inline with the text AND the note
@@ -122,7 +121,7 @@ class Page(xmlmap.XmlObject):
             # the parent of the tail text is the preceding element
             if text.is_tail and parent.tag == "GAP":
                 # if text precedes a GAP tag, include the display content
-                # from the DISP ` (for now)
+                # from the DISP (for now)
                 yield text.getparent().get("DISP")
 
             if text.is_tail and parent.tag == "PB":

--- a/ppa/archive/management/commands/eebo_import.py
+++ b/ppa/archive/management/commands/eebo_import.py
@@ -9,7 +9,7 @@ Solr as part of this import script (both works and pages).
 
 Example usage::
 
-    python manage.py eebo_import -c path/to/eebo_works.csv
+    python manage.py eebo_import path/to/eebo_works.csv
 
 """
 

--- a/ppa/archive/tests/test_eebo_tcp.py
+++ b/ppa/archive/tests/test_eebo_tcp.py
@@ -2,7 +2,7 @@ import os.path
 import types
 
 from django.test import override_settings
-from eulxml.xmlmap import load_xmlobject_from_file
+from eulxml.xmlmap import load_xmlobject_from_file, load_xmlobject_from_string
 
 from ppa.archive import eebo_tcp
 from ppa.archive.tests.test_models import FIXTURES_PATH
@@ -37,6 +37,58 @@ def test_eebo_tcp_page_contents():
     assert last_page_content.rstrip().endswith(
         "CHAP. XXXVIII. The Peroration. 258\nFINIS."
     )
+
+
+# sample xml pages with notes (minimal wrapping tags to load as a text)
+PAGE_WITH_NOTE = """<ETS><EEBO><TEXT><PB N="257" REF="198"/><LG>
+<L>Whom Monarchs like domestick Slaves obey'd,</L>
+<L>On the bleak Shoar now lies th' abandon'd King,</L>
+<L N="765"><NOTE N="*" PLACE="foot"><HI>This whole line is taken from Sir</HI> John Derhan.</NOTE> A headless Carcass, and a nameless thing.</L>
+</LG></TEXT></EEBO></ETS>"""
+PAGE_WITH_MULTIPLE_NOTES = """<ETS><EEBO><TEXT><P><PB N="3" REF="11"/>
+many Colonies. But now the several Languages that are used in the world do farre exceed this number.<NOTE PLACE="marg">Nat. Hist. lib. 6. cap. 5. <HI>Strabo,</HI> lib. 11.</NOTE> <HI>Pliny</HI> and <HI>Strabo</HI> do both make mention of a great Mart-Town in <HI>Colchos</HI> named <HI>Dioscuria,</HI> to which men of three hundred Nations, and of so many several Languages, were wont to resort for Trading. Which, considering the narrow compass of Traf∣fick before the invention of the magnetic Needle, must needs be but a small proportion, in comparison to those many of the remoter and un∣known parts of the world.</P>
+<P>Some of the <HI>American</HI> Histories relate,<NOTE PLACE="marg">Mr. <HI>Cambden</HI>'s Remains.</NOTE> that in every fourscore miles of that vast Country, and almost in every particular valley of <HI>Peru,</HI> the Inhabitants have a distinct Language. And one who for several years travelled the Northern parts of <HI>America</HI> about <HI>Florida,</HI><NOTE PLACE="marg"><HI>Purchas</HI> Pilg. lib. 8. sect. 4. chap. 1.</NOTE> and could speak six several Languages of those people, doth affirm, that he found, upon his enquiry and converse with them, more than a thousand different Lan∣guages amongst them.</P>
+<P>As for those Languages which seem to have no derivation from, or de∣pendance upon, or affinity with one another,<NOTE PLACE="marg">§. III.</NOTE> they are styled <HI>Linguae ma∣trices,</HI> or <HI>Mother-tongues.</HI> Of these <HI>Ioseph Scaliger</HI>
+ affirms there are ele∣ven, and not more, used in <HI>Europe</HI>;<NOTE PLACE="marg">Diatribe de Europaeorum linguis.</NOTE> whereof four are of more general and large extent, and the other seven of a narrower compass and use. Of the more general Tongues
+.</P></TEXT></EEBO></ETS>"""
+
+
+def test_text_inside_note():
+    text = load_xmlobject_from_string(PAGE_WITH_MULTIPLE_NOTES, eebo_tcp.Text)
+    page = text.pages[0]
+    # text directly inside a note tag (note is parent)
+    diatribe_note_text = text.node.xpath("//NOTE[contains(., 'Diatribe')]/text()")[0]
+    assert page.text_inside_note(diatribe_note_text) is not None
+    # text nested under a tag within a note tag (note is ancestor)
+    camden_note_text = text.node.xpath("//NOTE/HI[contains(., 'Cambden')]/text()")[0]
+    assert page.text_inside_note(camden_note_text)
+    # text in a tag that is NOT inside a note tag (note is not parent/ancestor)
+    europe_hi_text = text.node.xpath("//HI[contains(., 'Europe')]/text()")[0]
+    assert page.text_inside_note(europe_hi_text) is None
+
+
+def test_eebo_tcp_page_contents_notes():
+    # test that notes are placed at the end of the text instead of inline
+    text = load_xmlobject_from_string(PAGE_WITH_NOTE, eebo_tcp.Text)
+    page_contents = str(text.pages[0])
+    # should not display note contents inline
+    assert "taken from Sir John Derhan. A headless Carcass," not in page_contents
+    # should display a note marker inline
+    assert "* A headless Carcass" in page_contents
+    # should display note contents with marker at end of content
+    assert page_contents.endswith("* This whole line is taken from Sir John Derhan.")
+
+    text = load_xmlobject_from_string(PAGE_WITH_MULTIPLE_NOTES, eebo_tcp.Text)
+    page_contents = str(text.pages[0])
+    # notes should be displayed with markers in sequence
+    # all text within first note should be displayed as a single note, not multiple
+    assert "* Nat. Hist. lib. 6. cap. 5. Strabo, lib. 11." in page_contents
+    assert "† Mr. Cambden's Remains" in page_contents
+    assert "** Diatribe de Europaeorum linguis." in page_contents
+    # note markers should be displayed inline where note was located
+    assert "exceed this number.*" in page_contents
+    assert "Histories relate,† that" in page_contents
+    assert "used in Europe;** whereof" in page_contents
 
 
 def test_short_id():

--- a/ppa/archive/tests/test_eebo_tcp.py
+++ b/ppa/archive/tests/test_eebo_tcp.py
@@ -61,10 +61,24 @@ def test_text_inside_note():
     assert page.text_inside_note(diatribe_note_text) is not None
     # text nested under a tag within a note tag (note is ancestor)
     camden_note_text = text.node.xpath("//NOTE/HI[contains(., 'Cambden')]/text()")[0]
-    assert page.text_inside_note(camden_note_text)
+    assert page.text_inside_note(camden_note_text) is not None
     # text in a tag that is NOT inside a note tag (note is not parent/ancestor)
     europe_hi_text = text.node.xpath("//HI[contains(., 'Europe')]/text()")[0]
     assert page.text_inside_note(europe_hi_text) is None
+
+
+def test_get_note_mark():
+    text = load_xmlobject_from_string(PAGE_WITH_NOTE, eebo_tcp.Text)
+    page = text.pages[0]
+    # lower indexes should map exactly
+    assert page.get_note_mark(0) == "*"
+    assert page.get_note_mark(1) == "†"
+    assert page.get_note_mark(2) == "‡"
+    assert page.get_note_mark(3) == "§"
+    # when index goes past number of available 'marks, repeat the mark
+    assert page.get_note_mark(4) == "**"
+    assert page.get_note_mark(5) == "††"
+    assert page.get_note_mark(8) == "***"
 
 
 def test_eebo_tcp_page_contents_notes():

--- a/ppa/archive/tests/test_eebo_tcp.py
+++ b/ppa/archive/tests/test_eebo_tcp.py
@@ -44,7 +44,7 @@ def test_eebo_tcp_page_contents():
 PAGE_WITH_NOTE = """<ETS><EEBO><TEXT><PB N="257" REF="198"/><LG>
 <L>Whom Monarchs like domestick Slaves obey'd,</L>
 <L>On the bleak Shoar now lies th' abandon'd King,</L>
-<L N="765"><NOTE N="*" PLACE="foot"><HI>This whole line is taken from Sir</HI> John Derhan.</NOTE> A headless Carcass, and a nameless thing.</L>
+<L N="765"><NOTE N="✓" PLACE="foot"><HI>This whole line is taken from Sir</HI> John Derhan.</NOTE> A headless Carcass, and a nameless thing.</L>
 </LG></TEXT></EEBO></ETS>"""
 PAGE_WITH_MULTIPLE_NOTES = """<ETS><EEBO><TEXT><P><PB N="3" REF="11"/>
 many Colonies. But now the several Languages that are used in the 
@@ -108,10 +108,10 @@ def test_eebo_tcp_page_contents_notes():
     page_contents = str(text.pages[0])
     # should not display note contents inline
     assert "taken from Sir John Derhan. A headless Carcass," not in page_contents
-    # should display a note marker inline
-    assert "* A headless Carcass" in page_contents
+    # should display a note marker inline using  note marker from the xml
+    assert "✓ A headless Carcass" in page_contents
     # should display note contents with marker at end of content
-    assert page_contents.endswith("* This whole line is taken from Sir John Derhan.")
+    assert page_contents.endswith("✓ This whole line is taken from Sir John Derhan.")
 
     text = load_xmlobject_from_string(PAGE_WITH_MULTIPLE_NOTES, eebo_tcp.Text)
     page_contents = str(text.pages[0])

--- a/ppa/archive/tests/test_eebo_tcp.py
+++ b/ppa/archive/tests/test_eebo_tcp.py
@@ -39,6 +39,7 @@ def test_eebo_tcp_page_contents():
     )
 
 
+# ruff: noqa: E501
 # sample xml pages with notes (minimal wrapping tags to load as a text)
 PAGE_WITH_NOTE = """<ETS><EEBO><TEXT><PB N="257" REF="198"/><LG>
 <L>Whom Monarchs like domestick Slaves obey'd,</L>
@@ -46,25 +47,45 @@ PAGE_WITH_NOTE = """<ETS><EEBO><TEXT><PB N="257" REF="198"/><LG>
 <L N="765"><NOTE N="*" PLACE="foot"><HI>This whole line is taken from Sir</HI> John Derhan.</NOTE> A headless Carcass, and a nameless thing.</L>
 </LG></TEXT></EEBO></ETS>"""
 PAGE_WITH_MULTIPLE_NOTES = """<ETS><EEBO><TEXT><P><PB N="3" REF="11"/>
-many Colonies. But now the several Languages that are used in the world do farre exceed this number.<NOTE PLACE="marg">Nat. Hist. lib. 6. cap. 5. <HI>Strabo,</HI> lib. 11.</NOTE> <HI>Pliny</HI> and <HI>Strabo</HI> do both make mention of a great Mart-Town in <HI>Colchos</HI> named <HI>Dioscuria,</HI> to which men of three hundred Nations, and of so many several Languages, were wont to resort for Trading. Which, considering the narrow compass of Traf∣fick before the invention of the magnetic Needle, must needs be but a small proportion, in comparison to those many of the remoter and un∣known parts of the world.</P>
-<P>Some of the <HI>American</HI> Histories relate,<NOTE PLACE="marg">Mr. <HI>Cambden</HI>'s Remains.</NOTE> that in every fourscore miles of that vast Country, and almost in every particular valley of <HI>Peru,</HI> the Inhabitants have a distinct Language. And one who for several years travelled the Northern parts of <HI>America</HI> about <HI>Florida,</HI><NOTE PLACE="marg"><HI>Purchas</HI> Pilg. lib. 8. sect. 4. chap. 1.</NOTE> and could speak six several Languages of those people, doth affirm, that he found, upon his enquiry and converse with them, more than a thousand different Lan∣guages amongst them.</P>
-<P>As for those Languages which seem to have no derivation from, or de∣pendance upon, or affinity with one another,<NOTE PLACE="marg">§. III.</NOTE> they are styled <HI>Linguae ma∣trices,</HI> or <HI>Mother-tongues.</HI> Of these <HI>Ioseph Scaliger</HI>
- affirms there are ele∣ven, and not more, used in <HI>Europe</HI>;<NOTE PLACE="marg">Diatribe de Europaeorum linguis.</NOTE> whereof four are of more general and large extent, and the other seven of a narrower compass and use. Of the more general Tongues
-.</P></TEXT></EEBO></ETS>"""
+many Colonies. But now the several Languages that are used in the 
+world do farre exceed this number.<NOTE PLACE="marg">Nat. Hist. lib. 6. cap. 5. <HI>Strabo,</HI> lib. 11.</NOTE> 
+<HI>Pliny</HI> and <HI>Strabo</HI> do both make mention of a great Mart-Town 
+in <HI>Colchos</HI> named <HI>Dioscuria,</HI> to which men of three hundred 
+Nations, and of so many several Languages, were wont to resort for Trading. 
+Which, considering the narrow compass of Traf∣fick before the invention of 
+the magnetic Needle, must needs be but a small proportion, in comparison 
+to those many of the remoter and un∣known parts of the world.</P>
+<P>Some of the <HI>American</HI> Histories relate,<NOTE PLACE="marg">Mr. <HI>Cambden</HI>'s Remains.</NOTE> that in every
+ fourscore miles of that vast Country, and almost in every particular
+  valley of <HI>Peru,</HI> the Inhabitants have a distinct Language. 
+  And one who for several years travelled the Northern parts of 
+  <HI>America</HI> about <HI>Florida,</HI>
+  <NOTE PLACE="marg"><HI>Purchas</HI> Pilg. lib. 8. sect. 4. chap. 1.</NOTE> 
+  and could speak six several Languages of those people, doth affirm, that 
+  he found, upon his enquiry and converse with them, more than a thousand 
+  different Lan∣guages amongst them.</P>
+<P>As for those Languages which seem to have no derivation from, or 
+de∣pendance upon, or affinity with one another,<NOTE PLACE="marg">§. III.</NOTE> 
+they are styled <HI>Linguae ma∣trices,</HI> or <HI>Mother-tongues.</HI> 
+Of these <HI>Ioseph Scaliger</HI> affirms there are ele∣ven, and not more, 
+used in <HI>Europe</HI>;<NOTE PLACE="marg">Diatribe de Europaeorum linguis.</NOTE> whereof 
+four are of more general and large extent, and the 
+other seven of a narrower compass and use. Of the more general Tongues.</P>
+</TEXT></EEBO></ETS>"""
 
 
-def test_text_inside_note():
+def test_parent_note():
     text = load_xmlobject_from_string(PAGE_WITH_MULTIPLE_NOTES, eebo_tcp.Text)
     page = text.pages[0]
     # text directly inside a note tag (note is parent)
     diatribe_note_text = text.node.xpath("//NOTE[contains(., 'Diatribe')]/text()")[0]
-    assert page.text_inside_note(diatribe_note_text) is not None
+    assert page.parent_note(diatribe_note_text) is not None
     # text nested under a tag within a note tag (note is ancestor)
     camden_note_text = text.node.xpath("//NOTE/HI[contains(., 'Cambden')]/text()")[0]
-    assert page.text_inside_note(camden_note_text) is not None
+    assert page.parent_note(camden_note_text) is not None
     # text in a tag that is NOT inside a note tag (note is not parent/ancestor)
     europe_hi_text = text.node.xpath("//HI[contains(., 'Europe')]/text()")[0]
-    assert page.text_inside_note(europe_hi_text) is None
+    assert page.parent_note(europe_hi_text) is None
 
 
 def test_get_note_mark():

--- a/ppa/archive/tests/test_eebo_tcp.py
+++ b/ppa/archive/tests/test_eebo_tcp.py
@@ -108,7 +108,7 @@ def test_eebo_tcp_page_contents_notes():
     page_contents = str(text.pages[0])
     # should not display note contents inline
     assert "taken from Sir John Derhan. A headless Carcass," not in page_contents
-    # should display a note marker inline using  note marker from the xml
+    # should display a note marker inline using note marker from the xml
     assert "✓ A headless Carcass" in page_contents
     # should display note contents with marker at end of content
     assert page_contents.endswith("✓ This whole line is taken from Sir John Derhan.")


### PR DESCRIPTION
ref #665

Revise eebo-tcp page text generation to identify and collect notes on the text, display note markers inline, and note contents after main page content