### PR TITLE
PDF generation in Wagtail (#559)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "url": "https://github.com/Princeton-CDH/ppa-django.git"
     },
     "scripts": {
-        "dev": "webpack serve --progress --hot --inline",
+        "dev": "webpack serve --progress --hot",
         "dev:semantic": "gulp --gulpfile sitemedia/semantic/gulpfile.js",
         "start": "npm run dev",
         "test": "npm run test:unit && npm run test:a11y",

--- a/ppa/editorial/templates/wagtailadmin/panels/pdf_panel.html
+++ b/ppa/editorial/templates/wagtailadmin/panels/pdf_panel.html
@@ -1,0 +1,37 @@
+{% if docraptor_api_key %}
+    <div
+        data-controller="pdf"
+        data-pdf-url-value="{{ url }}"
+        data-pdf-apikey-value="{{ docraptor_api_key }}"
+    >
+        <h3 data-pdf-target="heading">Generate a PDF copy of this page:</h3>
+        <div>
+            <button
+                class="button button-secondary"
+                data-pdf-target="preview"
+                data-action="pdf#generatePdf"
+                type="button"
+            >
+                Generate preview PDF
+            </button>
+            <span data-pdf-target="downloadPreview"></span>
+            <p class="help">
+                Unlimited previews allowed, but will be watermarked.
+            </p>
+        </div>
+        <div>
+            <button
+                class="button button-secondary warning"
+                data-pdf-target="final"
+                data-action="pdf#generatePdf"
+                type="button"
+            >
+                Generate final PDF
+            </button>
+            <span data-pdf-target="downloadFinal"></span>
+            <p class="help">
+                Limited to 5 PDFs per month.
+            </p>
+        </div>
+    </div>
+{% endif %}

--- a/ppa/editorial/wagtail_hooks.py
+++ b/ppa/editorial/wagtail_hooks.py
@@ -1,0 +1,9 @@
+from django.utils.html import format_html
+
+from wagtail import hooks
+from webpack_loader.templatetags.webpack_loader import render_bundle
+
+
+@hooks.register("insert_editor_js")
+def editor_js():
+    return format_html(render_bundle({}, "pdf", "js"))

--- a/srcmedia/js/controllers/pdf.js
+++ b/srcmedia/js/controllers/pdf.js
@@ -1,0 +1,72 @@
+class PdfController extends window.StimulusModule.Controller {
+  static targets = [
+        "downloadFinal",
+        "downloadPreview",
+        "final",
+        "heading",
+        "preview",
+    ];
+    static values = { apikey: String, url: String };
+
+    connect() {
+        // if no published URL is present, disable functions and show message
+        if (!this.urlValue) {
+            this.headingTarget.innerHTML = "Publish this page to enable PDF generation.";
+            this.previewTarget.disabled = true;
+            this.finalTarget.disabled = true;
+        }
+    }
+
+    async generatePdf(evt) {
+        // use the DocRaptor API to generate a PDF of the published editorial
+        const isPreview = evt.target === this.previewTarget;
+        const downloadTarget = isPreview ? this.downloadPreviewTarget : this.downloadFinalTarget;
+
+        // set loading state
+        this.previewTarget.disabled = true;
+        this.finalTarget.disabled = true;
+        downloadTarget.innerText = "Loading...";
+
+        try {
+            // attempt API fetch
+            const res = await fetch("https://api.docraptor.com/docs", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify({
+                    user_credentials: this.apikeyValue,
+                    doc: {
+                        test: isPreview,
+                        document_type: "pdf",
+                        document_url:  this.urlValue,
+                    }
+                }),
+            });
+            if (!res.ok) {
+                // DocRaptor returns errors as UTF-8 text
+                const errorText = await res.text();
+                throw new Error(`Error: ${errorText}`);
+            }
+            // download PDF binary response as a blob, create a URL for it, and show link
+            const blob = await res.blob();
+            const url = URL.createObjectURL(blob);
+            const downloadLink = document.createElement("a");
+            downloadLink.href = url;
+            downloadLink.download = isPreview ? "preview.pdf" : "final.pdf";
+            downloadLink.textContent = "Download PDF";
+            downloadTarget.innerText = "";
+            downloadTarget.appendChild(downloadLink);
+        } catch(error) {
+            // show error msg to user
+            downloadTarget.innerText = error.message;
+        }
+
+        // stop loading state
+        this.previewTarget.disabled = false;
+        this.finalTarget.disabled = false;
+    }
+}
+
+// register with wagtail
+window.wagtail.app.register('pdf', PdfController);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -104,8 +104,9 @@ module.exports = env => ({
         extensions: ['.js', '.jsx', '.ts', '.tsx', '.json', '.scss'] // enables importing these without extensions
     },
     devServer: {
-        contentBase: path.join(__dirname, 'bundles'), // serve this as webroot
-        overlay: true,
+        static: {
+            directory: path.join(__dirname, 'bundles'), // serve this as webroot
+        },
         port: 3000,
         allowedHosts: ['localhost'],
         headers: {
@@ -113,10 +114,10 @@ module.exports = env => ({
             'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
             'Access-Control-Allow-Headers': 'X-Requested-With, content-type, Authorization',
         },
-        stats: { // hides file-level verbose output when server is running
-            children: false,
-            modules: false,
-        }
+        client: {
+            logging: 'warn',
+            overlay: true,
+        },
     },
     devtool: devMode ? 'eval-source-map' : 'source-map', // allow sourcemaps in dev & qa
     optimization: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,7 @@ module.exports = env => ({
         home: './js/home.js', // homepage (parallax)
         search: './js/search.js', // scripts & styles for search page
         searchWithin: './ts/searchWithin.ts', // components & styles for search within work page
+        pdf: './js/controllers/pdf.js' // wagtail stimulus extension for PDF generation
     },
     output: {
         path: path.resolve(__dirname, 'bundles'), // where to output bundles


### PR DESCRIPTION
**Associated Issue(s):** #559

### Notes

- My approach changed somewhat as I learned more about Wagtail, and to some extent DocRaptor.
   - For example, you can't just get rendered HTML/CSS easily out of Wagtail as it would appear published, without new templates; a `Page` form panel isn't by default aware of its own published URL; and there is some [special configuration](https://docs.wagtail.org/en/stable/extending/extending_client_side.html#extending-with-stimulus) to get custom JS running inside of it (it uses Stimulus!).
- Had to make some tweaks to the webpack config and npm script to get the JS dev server working. Looks like it hadn't been updated for Webpack 4 yet.
- Generation is near-instant, so async JS without persistence is totally fine.
- I ended up not saving it to Django storage or anything since you mentioned Zenodo; seems fine to me to just let the user download the PDF and then host it themselves.
- Leaving this as a draft due to the below issues, and because it's still pretty experimental so I haven't added unit tests.

### Issues

- I can't really test locally that it works to pass the Wagtail url from `get_url()` to DocRaptor, since that's on `localhost` and contains a lot of internal links to local content (css, js, images, etc). But I tested just manually passing the url `https://prosody.princeton.edu/editorial/2020/01/visualizing-collections/` and it worked fine.
   - ... though, it did have some gray vertical bars on the left and right, and the font size is rather large. Should I make any changes to the print layout CSS? [Here's what the output looks like](https://github.com/user-attachments/files/20233893/preview.1.pdf)

   - This also means we won't be able to test it on the test site unless we allow non-firewall access to it temporarily. (DocRaptor does support passing rendered HTML as `document_content`, but I assume that will still link to CSS/JS/images on the test site, which will cause permissions errors in DocRaptor.)
- It seems that the [Wagtail API](https://docs.wagtail.org/en/stable/advanced_topics/headless.html#page-preview) doesn't give us a way to programmatically request a preview/draft version of the page. So, out of the box we can only really send DocRaptor the published page URL.
   - Even if we had a preview URL, I'm not sure we could pass that along to DocRaptor; at least, we'd need to pass along the fully rendered HTML to avoid permissions issues. Even then, I'm not 100% sure it would work, and I'd need to test on a live server. (that isn't firewalled)
   - That said, it may be possible to generate a preview using [wagtail-headless-preview](https://github.com/torchbox/wagtail-headless-preview) if we want to go that route.
   - My current solution is just to prevent the user from accessing DocRaptor at all if the page is still a draft or has unpublished changes. (The latter is so that people don't save some changes without publishing, and then get confused when they aren't reflected in the PDF.)

Some other possible options:
- Somehow passing ONLY the article content to DocRaptor, instead of the entire rendered page… then we could fetch the contents of the local CSS bundle and include the whole thing in `<style>` tags. But the problem is that any inline images won't work if they're still relative, referencing localhost, or referencing the firewalled URL. Maybe that's acceptable for test environments.
- Requiring the user to supply the URL for DocRaptor, similar to how the startwords script works, and prompting them in help text to supply the published production URL.
