### PR TITLE
Fix redirect logic for DigitizedWorkDetailView

### DIFF
--- a/ppa/archive/views.py
+++ b/ppa/archive/views.py
@@ -314,9 +314,9 @@ class DigitizedWorkDetailView(AjaxTemplateMixin, SolrLastModifiedMixin, DetailVi
                 # (previously excerpt ids were based on digital page range)
                 digwork_oldid = source_qs.filter(
                     old_workid="%(source_id)s-p%(start_page)s" % self.kwargs
-                ).first()
-                if digwork_oldid:
-                    self.redirect_url = source_qs.first().get_absolute_url()
+                )
+                if digwork_oldid.exists():
+                    self.redirect_url = digwork_oldid.first().get_absolute_url()
 
         # otherwise, return a 404
         return qs


### PR DESCRIPTION
**Associated Issue(s):** N/A

### Changes in this PR
- Fix redirect in `DigitizedWorkDetailView.get_queryset` to point to a `DigitizedWork` matched by `old_workid`, if one exists

### Notes

- A test was suddenly failing on the `develop` branch, seemingly unrelated to my merged PR, and I wasn't able to replicate the failure locally.
- But it looks like the intended behavior of the redirect in `DigitizedWorkDetailView.get_queryset` wasn't in the code as written, so it makes sense this unit test would fail sometimes. Perhaps it happened to succeed before due to a quirk of DB fixture ordering that has suddenly changed in an unpredictable way.

Let me know if I should create some kind of issue to track this.
