### PR TITLE
Adjust styles for print (#710)

### DIFF
--- a/srcmedia/scss/print.scss
+++ b/srcmedia/scss/print.scss
@@ -95,7 +95,7 @@
 	}
 
 	main, #editorial p, #editorial h2, #editorial h3 {
-	    font-size: 20px;
+	    font-size: 18px;
 	}
 
 	h1 {

--- a/srcmedia/scss/print.scss
+++ b/srcmedia/scss/print.scss
@@ -95,7 +95,11 @@
 	}
 
 	main, #editorial p, #editorial h2, #editorial h3 {
-	    font-size: 18px;
+	    font-size: 16px;
+	}
+
+	#editorial figcaption *, #editorial .footnotes * {
+		font-size: 12px;
 	}
 
 	h1 {


### PR DESCRIPTION
**Associated Issue(s):** #710

### Changes in this PR

- Reduce print font size from 20px to 18px.

### Notes
_Include any additional notes that will help in the reviewing of this pull request_

- Using my browser to print to pdf, and using the tunnel with DocRaptor, I'm not seeing the background color issue. It only seems to be present on production right now, so it might be fixed. But we can see if it happens in QA once we get the VPN stuff worked out.
- I went with 18px since that seemed to be roughly 60 characters per line, and seems to look good. But we could reduce it further to 16px if that looks better.
  - [16px.pdf](https://github.com/user-attachments/files/20492039/16px.pdf)
  - [18px.pdf](https://github.com/user-attachments/files/20492038/18px.pdf)