### PR TITLE
Fix failing JS unit tests (#709)

### DIFF
--- a/srcmedia/js/modules/LazyLoad.js
+++ b/srcmedia/js/modules/LazyLoad.js
@@ -47,19 +47,19 @@ class ImageLazyLoader {
     /**
      * @param {Array<Element>} images
      */
-    constructor(images) {
+    constructor(images, loadImg = loadImage) {
         if ('IntersectionObserver' in window) {
             let observer = new IntersectionObserver((items, observer) => {
                 items.forEach(item => {
                     if (item.isIntersecting) {
-                        loadImage(item.target)
+                        loadImg(item.target)
                         observer.unobserve(item.target)
                     }
                 })
             })
             images.forEach(img => observer.observe(img))
         } else {
-            images.forEach(img => loadImage(img))
+            images.forEach(img => loadImg(img))
         }
     }
 }

--- a/srcmedia/test/unit/LazyLoad.spec.js
+++ b/srcmedia/test/unit/LazyLoad.spec.js
@@ -58,7 +58,18 @@ describe('ImageLazyLoader', () => {
         this.images = Array.from(document.querySelectorAll('img'))
     })
 
-    it('should call loadImage once per image if IntersectionObserver isn\'t available')
+
+    it('should call loadImage once per image if IntersectionObserver isn\'t available', function() {
+        // ensure IntersectionObserver undefined
+        const realIntersectionObserver = window.IntersectionObserver;
+        delete window.IntersectionObserver
+        // mock loadImage
+        const mockLoadImage = jasmine.createSpy('loadImage')
+        new ImageLazyLoader(this.images, mockLoadImage)
+        expect(mockLoadImage).toHaveBeenCalledTimes(this.images.length)
+        // restore IntersectionObserver
+        window.IntersectionObserver = realIntersectionObserver;
+    })
 
     it('should instantiate a single IntersectionObsever when created', function() {
         let mockIOConstructor = jasmine.createSpy().and.callThrough()

--- a/srcmedia/test/unit/LazyLoad.spec.js
+++ b/srcmedia/test/unit/LazyLoad.spec.js
@@ -89,18 +89,23 @@ describe('ImageLazyLoader', () => {
         expect(mockIOObserve).toHaveBeenCalledTimes(3)
     })
 
-    xit('should call unobserver() when each image is intersecting the viewport', function() {
+    it('should call unobserver() when each image is intersecting the viewport', function() {
         let mockIOUnobserve = jasmine.createSpy().and.callThrough()
-        let mockIOConstructor = jasmine.createSpy().and.callThrough()
+        let observerCallback
         class mockIntersectionObserver {
-            constructor() { mockIOConstructor() }
+            constructor(callback) {
+                observerCallback = callback
+            }
             observe() {}
             unobserve() { mockIOUnobserve() }
         }
         window.IntersectionObserver = mockIntersectionObserver
         this.loader = new ImageLazyLoader(this.images)
         let mockEntry = { isIntersecting: true, target: this.images[0] }
-        observerCallback([mockEntry])
+        // mock image entering the viewport
+        observerCallback([mockEntry], {
+            unobserve: mockIOUnobserve
+        })
         expect(mockIOUnobserve).toHaveBeenCalledWith(this.images[0])
     })
 

--- a/srcmedia/test/unit/NavMenu.spec.js
+++ b/srcmedia/test/unit/NavMenu.spec.js
@@ -31,12 +31,12 @@ describe('NavMenu', () => {
             const e = $.Event('keydown')
             e.keyCode = 40
             this.an.$textSelector.trigger(e)
-            expect($(':focus').length).toBe(1)
+            expect(document.activeElement.getAttribute('href')).toBe('/history/')
         })
 
     })
 
-    describe('feedbackHandler()', () => {
+    describe('keydownHandler()', () => {
 
         beforeEach(function () {
             loadFixtures('nav-menu.html')
@@ -46,31 +46,32 @@ describe('NavMenu', () => {
         it('moves up and down the menu based on arrow keys', function() {
             const down = 40
             const up = 38
-            const e = $.Event('keydown',
-                {
-                    keyCode: down,
-                    // set about as currentTarget and target for initial state
-                    currentTarget: document.getElementsByClassName('.about')[0],
-                    target: document.getElementsByClassName('.about')[0]
-                }
-            )
-            // start at about and walk down two
-            this.an.$textSelector.trigger(e)
-            expect($(':focus').attr('href')).toBe('/history/')
-            // get current focused DOM node and simulate the keydown correctly
-            e.target = $(':focus').get(0)
-            this.an.$textSelector.trigger(e)
-            expect($(':focus').attr('href')).toBe('/prosody/')
-            // now walk back up
-            e.keyCode = up
-            e.target = $(':focus').get(0)
-            $(':focus').trigger(e)
-            expect($(':focus').attr('href')).toBe('/history/')
-            e.target = $(':focus').get(0)
-            this.an.$textSelector.trigger(e)
-            // back to text (about)
-            expect($(':focus').hasClass('text')).toBeTruthy()
+            const text = document.querySelector('.about > .text')
+            const historyLink = document.querySelector('a[href="/history/"]')
+            const prosodyLink = document.querySelector('a[href="/prosody/"]')
 
+            spyOn(historyLink, 'focus').and.callThrough()
+            const e1 = $.Event('keydown', { keyCode: down })
+
+            // start at about and walk down two
+            $(text).trigger(e1);
+            expect(historyLink.focus).toHaveBeenCalled()
+
+            // get current focused DOM node and simulate the keydown correctly
+            spyOn(prosodyLink, 'focus').and.callThrough()
+            const e2 = $.Event('keydown', { keyCode: down })
+            $(historyLink).trigger(e2)
+            expect(prosodyLink.focus).toHaveBeenCalled()
+
+            // now walk back up
+            const e3 = $.Event('keydown', { keyCode: up })
+            $(prosodyLink).trigger(e3)
+            expect(document.activeElement.getAttribute('href')).toBe('/history/')
+
+            // back to text (about)
+            const e4 = $.Event('keydown', { keyCode: up })
+            $(historyLink).trigger(e4)
+            expect(document.activeElement.classList.contains('text')).toBe(true)
 
         })
     })

--- a/srcmedia/test/unit/ReactiveForm.spec.js
+++ b/srcmedia/test/unit/ReactiveForm.spec.js
@@ -73,7 +73,7 @@ describe('Reactive Form', () => {
             this.initialState = $('#form').serializeArray()
         })
 
-        xit('should get called when state changes', function(done) {
+        it('should get called when state changes', function(done) {
             $('#checkbox').click() // make a change
             expect(this.onStateChangeSpy).toHaveBeenCalledTimes(1)
             $('#text').val('hello') // make another change
@@ -112,7 +112,7 @@ describe('Reactive Form', () => {
         })
 
         // failing in ci, working locally
-        xit('should observe state changes for checkboxes', function() {
+        it('should observe state changes for checkboxes', function() {
             $('#checkbox').click() // checked
             expect(this.checkboxSpy).toHaveBeenCalledWith(true)
             $('#checkbox').click() // unchecked
@@ -126,16 +126,16 @@ describe('Reactive Form', () => {
             expect(this.radio1Spy).toHaveBeenCalledWith(true)
         })
 
-        xit('should observe state changes for text inputs', function(done) {
+        it('should observe state changes for text inputs', function(done) {
             $('#text').val('hello')
             $('#text')[0].dispatchEvent(new Event('input'))  // fake the input event
             setTimeout(() => {  // have to wait for the event to be picked up
                 expect(this.textSpy).toHaveBeenCalledWith('hello')
                 done()
-            }, 500)  // this comes from .debounceTime(500) on the method
+            }, 600)  // this comes from .debounceTime(500) on the method, + buffer
         })
 
-        xit('should ignore repeated values for text inputs', function(done) {
+        it('should ignore repeated values for text inputs', function(done) {
             $('#text').val('hello')
             $('#text')[0].dispatchEvent(new Event('input'))
             $('#text')[0].dispatchEvent(new Event('input'))
@@ -143,7 +143,7 @@ describe('Reactive Form', () => {
             setTimeout(() => {
                 expect(this.textSpy).toHaveBeenCalledTimes(1)
                 done()
-            }, 500)
+            }, 600)
         })
 
         it('should observe state changes for number inputs', function(done) {
@@ -152,10 +152,10 @@ describe('Reactive Form', () => {
             setTimeout(() => {
                 expect(this.numberSpy).toHaveBeenCalledWith('1990')
                 done()
-            }, 500)
+            }, 600)
         })
 
-        xit('should ignore repeated values for number inputs', function(done) {
+        it('should ignore repeated values for number inputs', function(done) {
             $('#number').val('1990')
             $('#number')[0].dispatchEvent(new Event('input'))
             $('#number')[0].dispatchEvent(new Event('input'))
@@ -163,7 +163,7 @@ describe('Reactive Form', () => {
             setTimeout(() => {
                 expect(this.numberSpy).toHaveBeenCalledTimes(1)
                 done()
-            }, 500)
+            }, 600)
         })
     })
 })

--- a/srcmedia/test/unit/ReactiveForm.spec.js
+++ b/srcmedia/test/unit/ReactiveForm.spec.js
@@ -111,7 +111,6 @@ describe('Reactive Form', () => {
             })
         })
 
-        // failing in ci, working locally
         it('should observe state changes for checkboxes', function() {
             $('#checkbox').click() // checked
             expect(this.checkboxSpy).toHaveBeenCalledWith(true)


### PR DESCRIPTION
**Associated Issue(s):** #709

### Changes in this PR

- Fix failing JS unit tests. Most were intermittent timing-related failures, one failed consistently (`unobserver()`) and required refactoring.
- Add a missing JS unit test (no `IntersectionObserver` in `window`)