### PR TITLE
Bump Wagtail to 7.0 (#721)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ lxml
 # TODO: switch to released neuxml when 1.0.0 is out
 git+https://github.com/Princeton-CDH/neuxml@main
 # neuxml
-wagtail>=6.4,<6.5
+wagtail>=7.0,<7.1
 django-taggit>=4.0
 bleach
 django-fullurl


### PR DESCRIPTION
**Associated Issue(s):** #721

### Changes in this PR

- Bump wagtail to 7.0

### Notes

- I figured I would just go ahead and do this since the upgrade itself and the research were altogether less than an hour.
- I tested this locally, in particular testing [validation on saving drafts](https://docs.wagtail.org/en/stable/releases/7.0.html#configuring-deferred-validation-of-required-fields) and [JS presence](https://docs.wagtail.org/en/stable/releases/7.0.html#removal-of-insert-editor-js-hook-output-in-some-non-editor-views) with editorial and pages, and it worked fine.