### PR TITLE
Wagtail: Use page.full_url, update dev notes

### DIFF
--- a/DEVELOPERNOTES.rst
+++ b/DEVELOPERNOTES.rst
@@ -166,7 +166,10 @@ public with a service like Cloudflare Tunnel, e.g.::
 
 Then in Wagtail Site settings, set the default Site's hostname to the tunnel's
 public hostname (no protocol/slashes), and port 80. That way,
-``GeneratePdfPanel.BoundPanel.instance.get_url()`` resolves to a public URL.
+``GeneratePdfPanel.BoundPanel.instance.full_url`` resolves to a public URL.
+
+Finally, set your ALLOWED_HOSTS setting to allow traffic via that domain,
+or simply set ``ALLOWED_HOSTS = ["*"]``.
 
 Note that this will not work in Webpack dev mode.
 

--- a/ppa/editorial/models.py
+++ b/ppa/editorial/models.py
@@ -129,7 +129,7 @@ class GeneratePdfPanel(Panel):
 
             # NOTE: See DEVELOPERNOTES.rst for instructions to test this in
             # development, under "Testing local DocRaptor PDF generation."
-            url = self.instance.get_url()
+            url = self.instance.full_url
 
             # disable if unpublished, or has unpublished changes
             if (

--- a/ppa/editorial/tests.py
+++ b/ppa/editorial/tests.py
@@ -159,7 +159,7 @@ class TestGeneratePdfPanel:
         context = bound_panel.get_context_data()
 
         # should use page's URL
-        assert context["url"] == page.get_url()
+        assert context["url"] == page.full_url
 
         # make an unpublished change. URL should now be an empty string
         page.title = "test"
@@ -173,7 +173,7 @@ class TestGeneratePdfPanel:
         page.refresh_from_db()
         bound_panel = panel.bind_to_model(EditorialPage).get_bound_panel(instance=page)
         context = bound_panel.get_context_data()
-        assert context["url"] == page.get_url()
+        assert context["url"] == page.full_url
 
 
 class TestDocraptorSettings(TestCase):


### PR DESCRIPTION
**Associated Issue(s):** N/A

### Changes in this PR
_Include all key changes in this pull request_

- Minor tweaks for wagtail from S&Co work:
  - Use `Page.full_url` instead of `get_url` to ensure an absolute url for DocRaptor
  - Update dev notes to mention allowed_hosts issue
