### PR TITLE
Include cluster result text in results_list (#547)

### DIFF
--- a/ppa/archive/templates/archive/snippets/results_list.html
+++ b/ppa/archive/templates/archive/snippets/results_list.html
@@ -5,7 +5,7 @@ via ajax, e.g. to update the search results.
 {% endcomment %}
 <div class="data">
     <pre class="count">
-        Displaying {{ paginator.count|intcomma }} digitized work{{ paginator.count|pluralize }}
+        Displaying {{ paginator.count|intcomma }} digitized work{{ paginator.count|pluralize }}{% if not search_form.cluster.value %} or cluster{{ paginator.count|pluralize }} of works{% endif %}
     </pre>
     {{ facet_ranges.pub_date|json_script:"facets" }}
 </div>

--- a/ppa/archive/templates/archive/snippets/search_form.html
+++ b/ppa/archive/templates/archive/snippets/search_form.html
@@ -82,7 +82,7 @@
     </div>
     <input type="submit" class="sr-only sr-only-focusable" aria-label="submit search">
     <div class="workscount ui center aligned text container">
-        <p class="count">Displaying {{ paginator.count|intcomma }} digitized work{{ paginator.count|pluralize }}{% if not search_form.cluster.value %} or clusters of works{% endif %}</p>
+        <p class="count">Displaying {{ paginator.count|intcomma }} digitized work{{ paginator.count|pluralize }}{% if not search_form.cluster.value %} or cluster{{ paginator.count|pluralize }} of works{% endif %}</p>
         <p class="zotero">Work citations can be exported to <a href="https://www.zotero.org/support/getting_stuff_into_your_library">Zotero</a></p>
         <div class="loader">
             <img src="{% static 'img/loader/search-loader.gif' %}" alt="">


### PR DESCRIPTION
**Associated Issue(s):** #547

### Changes in this PR

- Update `results_list.html` template, which replaces part of `search_results.html` via async JS, to include its "or clusters of works" text
- Use count pluralization on the word "cluster" too, in case the result is 1 cluster of works