### PR TITLE
Always show number of matching pages (#388)

### DIFF
--- a/ppa/archive/templates/archive/snippets/search_result.html
+++ b/ppa/archive/templates/archive/snippets/search_result.html
@@ -96,11 +96,9 @@
     <div class="page-previews container">
         {% if page_groups and page_highlights %}
         {% with results=page_groups|dict_item:item.id %}
-            {% if results.numFound > 2 %}
             <span class="total-pages">
                 {{ results.numFound|intcomma }} matching page{{ results.numFound|pluralize }}
             </span>
-            {% endif %}
             <div class="pages">
                 {% if page_highlights %}
                 <div class="wrapper">


### PR DESCRIPTION
**Associated Issue(s):** #388

### Changes in this PR

- If there are any page matches (`page_groups`/`page_highlights`), always show the number of pages matched