### PR TITLE
Increase debounce time to 750ms (#300)

### DIFF
--- a/srcmedia/js/modules/ReactiveForm.js
+++ b/srcmedia/js/modules/ReactiveForm.js
@@ -26,7 +26,7 @@ export default class ReactiveForm {
             default:
                 return observable.pipe(
                     map(e => e.target.value), // returns string
-                    debounceTime(500), // filter out fast repetitive events
+                    debounceTime(750), // filter out fast repetitive events
                     distinctUntilChanged(), // filter out non-changes
                 )
         }

--- a/srcmedia/test/unit/ReactiveForm.spec.js
+++ b/srcmedia/test/unit/ReactiveForm.spec.js
@@ -81,7 +81,7 @@ describe('Reactive Form', () => {
             setTimeout(() => { // have to wait for the event to be picked up
                 expect(this.onStateChangeSpy).toHaveBeenCalledTimes(2)
                 done()
-            }, 500) // this comes from .debounceTime(500) on fromInput()
+            }, 850) // this comes from .debounceTime(750) on fromInput()
         })
 
         it('should receive the state as a parameter', function() {
@@ -131,7 +131,7 @@ describe('Reactive Form', () => {
             setTimeout(() => {  // have to wait for the event to be picked up
                 expect(this.textSpy).toHaveBeenCalledWith('hello')
                 done()
-            }, 600)  // this comes from .debounceTime(500) on the method, + buffer
+            }, 850)  // this comes from .debounceTime(750) on the method, + buffer
         })
 
         it('should ignore repeated values for text inputs', function(done) {
@@ -142,7 +142,7 @@ describe('Reactive Form', () => {
             setTimeout(() => {
                 expect(this.textSpy).toHaveBeenCalledTimes(1)
                 done()
-            }, 600)
+            }, 850)
         })
 
         it('should observe state changes for number inputs', function(done) {
@@ -151,7 +151,7 @@ describe('Reactive Form', () => {
             setTimeout(() => {
                 expect(this.numberSpy).toHaveBeenCalledWith('1990')
                 done()
-            }, 600)
+            }, 850)
         })
 
         it('should ignore repeated values for number inputs', function(done) {
@@ -162,7 +162,7 @@ describe('Reactive Form', () => {
             setTimeout(() => {
                 expect(this.numberSpy).toHaveBeenCalledTimes(1)
                 done()
-            }, 600)
+            }, 850)
         })
     })
 })

--- a/srcmedia/ts/lib/input.ts
+++ b/srcmedia/ts/lib/input.ts
@@ -70,7 +70,7 @@ class RxTextInput extends RxInput implements Reactive<RxTextInputState> {
         // Update state when the user types in a new value, with debounce
         fromEvent(this.element, 'input').pipe(
             map(() => ({ value: this.element.value })),
-            debounceTime(500),
+            debounceTime(750),
             distinctUntilChanged()
         ).subscribe(this.update)
     }


### PR DESCRIPTION
**Associated Issue(s):** #300

### Changes in this PR

- Bump debounce time for form fields from 500 to 750ms

### Notes

- I went with 750ms because while 500ms seems reasonable to me, 1000ms means I actually have to wait for results to start showing up; it feels sluggish. But this is subjective and really depends on the person's typing speed.
- The original issue notes that it seems fixed for some fields but not others, but the debounce time is the same for all three, and theoretically this should be independent of data load times because the loading indicator should show up regardless. But maybe it's just a quirk of how people are using it?