### PR TITLE
Use GracefulPaginator in work detail view (#297)

### DIFF
--- a/ppa/archive/views.py
+++ b/ppa/archive/views.py
@@ -294,6 +294,7 @@ class DigitizedWorkDetailView(AjaxTemplateMixin, SolrLastModifiedMixin, DetailVi
     slug_url_kwarg = "source_id"
     form_class = SearchWithinWorkForm
     paginate_by = 50
+    paginator_class = GracefulPaginator
     # redirect url for a full volume converted to a single excerpt
     redirect_url = None
 


### PR DESCRIPTION
**Associated Issue(s):** #297

### Changes in this PR

- Minor tweak to use the `GracefulPaginator` in the work detail view search, and not just the archive search