### PR TITLE
Add EditorialPage tags frontend display and filtering (#719)

### DIFF
--- a/ppa/editorial/templates/editorial/editorial_index_page.html
+++ b/ppa/editorial/templates/editorial/editorial_index_page.html
@@ -20,7 +20,7 @@
         <div class="page-description">{{ page.intro|richtext }}</div>
         {% if tags %}
             <div class="page-tags">
-                <span class="tags-label">Tags</span>:
+                <span class="tags-label">Filter by tag</span>:
                 {% for tag in tags %}
                     <a href="?{% querystring_replace tag=tag.slug %}"{% if selected_tag == tag.slug %} class="selected"{% endif %}>{{ tag }}</a>
                     ({{ tag.count }}){% if not forloop.last %}, {% endif %}

--- a/ppa/editorial/templates/editorial/editorial_index_page.html
+++ b/ppa/editorial/templates/editorial/editorial_index_page.html
@@ -23,14 +23,11 @@
                 <span class="tags-label">Filter by tag</span>:
                 {% for tag in tags %}
                     <a href="?{% querystring_replace tag=tag.slug %}"{% if selected_tag == tag.slug %} class="selected"{% endif %}>{{ tag }}</a>
-                    ({{ tag.count }}){% if not forloop.last %}, {% endif %}
+                    ({{ tag.count }})
                 {% endfor %}
             </div>
             {% if selected_tag %}
-                <a href="{{ page.url }}" class="clear-filter">
-                    <img src="{% static 'img/icons/Delete.svg' %}" alt="Clear filter">
-                    <span>Clear filter</span>
-                </a>
+                <a href="{{ page.url }}" class="clear-filter">View all</a>
             {% endif %}
         {% endif %}
     </div>

--- a/ppa/editorial/templates/editorial/editorial_index_page.html
+++ b/ppa/editorial/templates/editorial/editorial_index_page.html
@@ -1,5 +1,5 @@
 {% extends 'pages/content_page.html' %}
-{% load wagtailcore_tags %}
+{% load wagtailcore_tags static %}
 
 {% block page-context-id %}list-editorial{% endblock %}
 
@@ -18,6 +18,21 @@
             {% firstof page.title page_title object.title %}
         </h1>
         <div class="page-description">{{ page.intro|richtext }}</div>
+        {% if tags %}
+            <div class="page-tags">
+                <span class="tags-label">Tags</span>:
+                {% for tag in tags %}
+                    <a href="?{% querystring_replace tag=tag.slug %}"{% if selected_tag == tag.slug %} class="selected"{% endif %}>{{ tag }}</a>
+                    ({{ tag.count }}){% if not forloop.last %}, {% endif %}
+                {% endfor %}
+            </div>
+            {% if selected_tag %}
+                <a href="{{ page.url }}" class="clear-filter">
+                    <img src="{% static 'img/icons/Delete.svg' %}" alt="Clear filter">
+                    <span>Clear filter</span>
+                </a>
+            {% endif %}
+        {% endif %}
     </div>
 </div>
 <div class="ui vertical basic segment">

--- a/ppa/editorial/templates/editorial/snippets/attribution.html
+++ b/ppa/editorial/templates/editorial/snippets/attribution.html
@@ -45,7 +45,7 @@
 {% if page.tags.exists %}
     <p class="tags">
         {% for tag in page.tags.all %}
-            <a href="{% pageurl page.get_parent %}?tag={{ tag.slug }}">#{{ tag }}</a>
+            <a href="{% pageurl page.get_parent %}?tag={{ tag.slug }}">{{ tag }}</a>
         {% endfor %}
     </p>
     {% endif %}

--- a/ppa/editorial/templates/editorial/snippets/attribution.html
+++ b/ppa/editorial/templates/editorial/snippets/attribution.html
@@ -1,3 +1,5 @@
+{% load wagtailcore_tags %}
+
 {# Snippet to include authors and date attribution to editorial posts #}
 {% if page.authors %}
     <p class="author">
@@ -40,4 +42,12 @@
 {% if page.pdf %}
  <a href="{{ page.pdf }}" rel="alternate" class="pdf">PDF</a>
 {% endif %}
+{% if page.tags.exists %}
+    <p class="tags">
+        Tags:
+        {% for tag in page.tags.all %}
+            <a href="{% pageurl page.get_parent %}?tag={{ tag.slug }}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
+        {% endfor %}
+    </p>
+    {% endif %}
 {% endif %}

--- a/ppa/editorial/templates/editorial/snippets/attribution.html
+++ b/ppa/editorial/templates/editorial/snippets/attribution.html
@@ -44,9 +44,8 @@
 {% endif %}
 {% if page.tags.exists %}
     <p class="tags">
-        Tags:
         {% for tag in page.tags.all %}
-            <a href="{% pageurl page.get_parent %}?tag={{ tag.slug }}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
+            <a href="{% pageurl page.get_parent %}?tag={{ tag.slug }}">#{{ tag }}</a>
         {% endfor %}
     </p>
     {% endif %}

--- a/srcmedia/scss/pages/_editorial.scss
+++ b/srcmedia/scss/pages/_editorial.scss
@@ -26,6 +26,15 @@
             margin-bottom: 0;
             @include font-scale;
         }
+        .tags {
+            font-size: 1rem;
+            @media (min-width: $tablet) {
+                font-size: 1.5rem;
+            }
+            a::before {
+                content: "#";
+            }
+        }
     }
 }
 

--- a/srcmedia/scss/pages/_list-editorial.scss
+++ b/srcmedia/scss/pages/_list-editorial.scss
@@ -23,6 +23,29 @@
             font-size: 1.5rem;
         }
     }
+    .page-tags {
+        span.tags-label,
+        a.selected {
+            font-weight: 600;
+        }
+        @media (min-width: $tablet) {
+            font-size: 1.2rem;
+        }
+    }
+    a.clear-filter {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        margin-top: 1rem;
+        @media (min-width: $tablet) {
+            font-size: 1.2rem;
+        }
+        img {
+            margin: 0;
+            height: 1.25rem;
+            width: 1.25rem;
+        }
+    }
 
     .updates {
         margin-bottom: 4rem;

--- a/srcmedia/scss/pages/_list-editorial.scss
+++ b/srcmedia/scss/pages/_list-editorial.scss
@@ -28,6 +28,9 @@
         a.selected {
             font-weight: 600;
         }
+        a::before {
+            content: "#";
+        }
         @media (min-width: $tablet) {
             font-size: 1.2rem;
         }

--- a/srcmedia/scss/print.scss
+++ b/srcmedia/scss/print.scss
@@ -148,7 +148,8 @@
 				display: none !important;
 			}
 		}
-		.pdf {  // hide link to pdf (since this is used to generate pdf)
+		.pdf, // hide link to pdf (since this is used to generate pdf)
+		.tags { // hide tags
 			display: none;
 		}
 	}


### PR DESCRIPTION
**Associated Issue(s):** #719

### Changes in this PR

- Display tags and counts on the editorial landing page
- Make tags links that take you to a filtered view listing editorial essays with that tag
   - Include a "clear filter" button, and a selected state for the chosen tag
- Display tags on individual editorial page as a link to other essays in that category
   - Exclude from print style


### Notes

I tried to make the design as simple as possible, here's what it looks like now. 

**Index page desktop**:

![Screenshot 2025-06-17 at 4 03 53 PM](https://github.com/user-attachments/assets/b3b6c3be-3225-4cf9-85b9-205774960c1c)
![Screenshot 2025-06-17 at 4 04 06 PM](https://github.com/user-attachments/assets/85b9ea76-d1ef-480e-9ce6-cf3fc6fb45ea)

**Index page mobile**:

![Screenshot 2025-06-17 at 4 04 52 PM](https://github.com/user-attachments/assets/88930fc5-859f-4b7d-a24e-bbd7e3353d6f)

**Editorial page desktop**:

![Screenshot 2025-06-17 at 4 01 53 PM](https://github.com/user-attachments/assets/9a5c0e44-7e37-45f0-b452-068dfdc94e39)

**Editorial page mobile**:

![Screenshot 2025-06-17 at 4 02 04 PM](https://github.com/user-attachments/assets/77864ad9-7323-4f18-8af2-63c2b174ca95)
