### PR TITLE
Reinitialize popups after search (#716)

### DIFF
--- a/srcmedia/js/search.js
+++ b/srcmedia/js/search.js
@@ -66,6 +66,7 @@ $(function(){
             }))
             $('.workscount').removeClass('loading') // turn off the loader
             new ImageLazyLoader($('img[data-src]').get()) // re-bind lazy loaded images
+            $('.source-popup').popup({hoverable: true}) // initialize tooltip popups in results
         })
         advancedSearchIndicator()
     }


### PR DESCRIPTION
**Associated Issue(s):** #716

### Changes in this PR

- Fix popup initialization: Tooltip `popup` instances from semantic UI have to be manually initialized, which they were on page load. When search results are replaced asynchronously, popups were not being reinitialized.