### PR TITLE
minor fix for Zotero and index logging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,13 +7,17 @@ CHANGELOG
 ----
 
 Zotero Integration Enhancement:
+
 - Improve Zotero integration by changing the old method of MARC and unAPI to COinS metadata.
 - This allows Zotero to automatically detect and import citation data from the PPA archive with the correct item type, PPA URL, page range, etc.
+
+User Experience Improvements:
 
 - As a researcher, I want to see the source of the works in my results, so that I can see where the texts are coming from.
 - Revise footer to make menu more flexible (and support moving Technical content page to "About" menu so it is easier to find)
 
 Editorial improvements:
+
 - As a content editor, I want to add tags to editorial essays so I can categorize and group essays for discovery.
 - As a content editor, I want a way to generating PDFs from editorial essays without developer assistance, so that I can deposit versions of the essays for DOIs.
 - As a user, I want to discover and navigate editorial essays by tag so I can find the content most relevant to my interests.
@@ -21,6 +25,7 @@ Editorial improvements:
 - Add configuration for DocRaptor API key in Wagtail settings
 
 Maintenance updates and bug fixes:
+
 - Upgraded to Python 3.12, Django 5.2, Wagtail 7.0
 - Replace deprecated calls in JS/TS code
 - bugfix: disallow requesting nonexistent result pages in archive search pagination
@@ -32,6 +37,7 @@ Maintenance updates and bug fixes:
 - bugfix: handle 500 error from Gale API when indexing pages
 
 Developer Documentation:
+
 - Document how to get PPA full-text content for local development
 
 

--- a/ppa/archive/admin.py
+++ b/ppa/archive/admin.py
@@ -185,10 +185,10 @@ class DigitizedWorkAdmin(ExportActionMixin, ExportMixin, admin.ModelAdmin):
         if obj.pages_digital:
             if obj.source == DigitizedWork.HATHI:
                 # hathi page url method requires source id
-                source_url = hathi_page_url(obj.source_id, obj.first_page_digital())
+                source_url = hathi_page_url(obj.source_id, obj.first_page_digital)
             if obj.source == DigitizedWork.GALE:
                 # gale page url method requires source url
-                source_url = gale_page_url(obj.source_url, obj.first_page_digital())
+                source_url = gale_page_url(obj.source_url, obj.first_page_digital)
         return mark_safe(
             '<a href="%s" target="_blank">%s</a>' % (source_url, obj.source_id)
         )

--- a/ppa/archive/gale.py
+++ b/ppa/archive/gale.py
@@ -79,6 +79,9 @@ class GaleAPI:
     #: base URL for all API requests
     api_root = "https://api.gale.com/api"
 
+    #: maximum number of retry attempts for API requests
+    max_retries = 3
+
     #: shared singleton instance; populated on first instantiation
     instance = None
 
@@ -142,11 +145,15 @@ class GaleAPI:
             rqst_opts["params"]["api_key"] = self.api_key
 
         resp = self.session.get(rqst_url, stream=stream, **rqst_opts)
-        logger.debug(
-            "get %s %s: %f sec",
+        # Log request - use info level for retries, debug for initial attempts
+        log_level = logger.info if retry > 0 else logger.debug
+        retry_info = f" (retry {retry}/{self.max_retries})" if retry > 0 else ""
+        log_level(
+            "get %s %s: %f sec%s",
             rqst_url,
             resp.status_code,
             resp.elapsed.total_seconds(),
+            retry_info,
         )
         if resp.status_code == requests.codes.ok:
             return resp
@@ -160,32 +167,18 @@ class GaleAPI:
             requests.codes.unauthorized,
             requests.codes.server_error,
         ]:
-            # Extract item ID from the URL (format: .../v1/item/GALE%7C{item_id})
-            item_id = None
-            if "GALE%7C" in rqst_url:
-                item_id = rqst_url.split("GALE%7C")[-1]
-
             # occasionally we get a 500 error when indexing all pages
             # refreshing API key and trying again, but log the error
             if resp.status_code == requests.codes.server_error:
-                # Log concise error info (status, URL, item ID)
-                logger.error(
-                    f"500 server error on {rqst_url}, Item ID: {item_id or 'N/A'}"
-                )
+                # Log concise error info (status, URL)
+                logger.error(f"500 server error on {rqst_url}")
 
             # If we get a 401 or 500 on a request that requires an api key,
-            # get a fresh key and then try the same request again (up to 3 retry attempts)
-            if requires_api_key and retry < 3:
-                # Log retry attempt for debugging - helps track API key refresh success
-                current_attempt = retry + 1
-                logger.info(
-                    f"Retrying after refreshing API key (attempt {current_attempt}/3) "
-                    f"- Status: {resp.status_code}, Item ID: {item_id or 'N/A'}"
-                )
-
+            # get a fresh key and then try the same request again (up to max_retries attempts)
+            if requires_api_key and retry < self.max_retries:
                 self.refresh_api_key()
 
-                retry_response = self._make_request(
+                return self._make_request(
                     url,
                     params=params,
                     requires_api_key=requires_api_key,
@@ -193,23 +186,13 @@ class GaleAPI:
                     retry=retry + 1,
                 )
 
-                # Log successful retry - confirms API key refresh worked and API call succeeded
-                logger.info(
-                    f"Retry succeeded with HTTP {retry_response.status_code} "
-                    f"(attempt {current_attempt}/3) - Item ID: {item_id or 'N/A'}"
+            # Log when we decide not to retry
+            if requires_api_key and retry >= self.max_retries:
+                logger.warning(
+                    f"Not retrying - {self.max_retries} retries exhausted, URL: {rqst_url}"
                 )
-
-                return retry_response
-            else:
-                # Log when we decide not to retry (doesn't require API key or max retries)
-                if requires_api_key and retry >= 3:
-                    logger.warning(
-                        f"Not retrying - 3 retries exhausted, Item ID: {item_id or 'N/A'}"
-                    )
-                elif not requires_api_key:
-                    logger.warning(
-                        f"Not retrying - no API key required, Item ID: {item_id or 'N/A'}"
-                    )
+            elif not requires_api_key:
+                logger.warning(f"Not retrying - no API key required, URL: {rqst_url}")
 
             # response is html error, not json; could try
             # extracting h1, but not sure it's worth parsing

--- a/ppa/archive/gale.py
+++ b/ppa/archive/gale.py
@@ -160,23 +160,57 @@ class GaleAPI:
             requests.codes.unauthorized,
             requests.codes.server_error,
         ]:
+            # Extract item ID from the URL (format: .../v1/item/GALE%7C{item_id})
+            item_id = None
+            if "GALE%7C" in rqst_url:
+                item_id = rqst_url.split("GALE%7C")[-1]
+
             # occasionally we get a 500 error when indexing all pages
             # refreshing API key and trying again, but log the error
             if resp.status_code == requests.codes.server_error:
-                # Not sure yet if response has any meaningful content
-                logger.error(f"500 error on {rqst_url}: {resp.content}")
+                # Log concise error info (status, URL, item ID)
+                logger.error(
+                    f"500 server error on {rqst_url}, Item ID: {item_id or 'N/A'}"
+                )
 
             # If we get a 401 or 500 on a request that requires an api key,
-            # get a fresh key and then try the same request again
-            if requires_api_key and retry < 1:
+            # get a fresh key and then try the same request again (up to 3 retry attempts)
+            if requires_api_key and retry < 3:
+                # Log retry attempt for debugging - helps track API key refresh success
+                current_attempt = retry + 1
+                logger.info(
+                    f"Retrying after refreshing API key (attempt {current_attempt}/3) "
+                    f"- Status: {resp.status_code}, Item ID: {item_id or 'N/A'}"
+                )
+
                 self.refresh_api_key()
-                return self._make_request(
+
+                retry_response = self._make_request(
                     url,
                     params=params,
                     requires_api_key=requires_api_key,
                     stream=stream,
                     retry=retry + 1,
                 )
+
+                # Log successful retry - confirms API key refresh worked and API call succeeded
+                logger.info(
+                    f"Retry succeeded with HTTP {retry_response.status_code} "
+                    f"(attempt {current_attempt}/3) - Item ID: {item_id or 'N/A'}"
+                )
+
+                return retry_response
+            else:
+                # Log when we decide not to retry (doesn't require API key or max retries)
+                if requires_api_key and retry >= 3:
+                    logger.warning(
+                        f"Not retrying - 3 retries exhausted, Item ID: {item_id or 'N/A'}"
+                    )
+                elif not requires_api_key:
+                    logger.warning(
+                        f"Not retrying - no API key required, Item ID: {item_id or 'N/A'}"
+                    )
+
             # response is html error, not json; could try
             # extracting h1, but not sure it's worth parsing
             raise GaleUnauthorized()

--- a/ppa/archive/management/commands/check_hathi_excerpts.py
+++ b/ppa/archive/management/commands/check_hathi_excerpts.py
@@ -57,7 +57,7 @@ class Command(BaseCommand):  # pragma: no cover
                     "pages_orig": digwork.pages_orig,
                     "pages_digital": digwork.pages_digital,
                     "old_hathi_start": hathi_page_url(
-                        digwork.source_id, digwork.first_page_digital()
+                        digwork.source_id, digwork.first_page_digital
                     ),
                 }
                 # NOTE: mets loading copied from hathi_page_index_data method
@@ -85,9 +85,9 @@ class Command(BaseCommand):  # pragma: no cover
                 # that would be included with current digital range (1-based index)
 
                 try:
-                    excerpt_first_page = page_info[digwork.first_page_digital() - 1]
+                    excerpt_first_page = page_info[digwork.first_page_digital - 1]
                 except IndexError:
-                    if digwork.first_page_digital() >= len(page_info):
+                    if digwork.first_page_digital >= len(page_info):
                         excerpt_first_page[-1]
                         info["notes"] = "digital page out of range; trying last page"
 
@@ -105,12 +105,12 @@ class Command(BaseCommand):  # pragma: no cover
 
                 # check if METS page label for the first page in range
                 # matches the desired first original page
-                if excerpt_first_page["label"] != str(digwork.first_page_original()):
+                if excerpt_first_page["label"] != str(digwork.first_page_original):
                     info["orig_label_match"] = "N"
                     # if they don't match, can we calculate the offset?
                     # (only works for numeric page labels)
                     try:
-                        diff = int(digwork.first_page_original()) - int(
+                        diff = int(digwork.first_page_original) - int(
                             excerpt_first_page["label"]
                         )
                         # calculate the expected new digital page range

--- a/ppa/archive/models.py
+++ b/ppa/archive/models.py
@@ -526,7 +526,7 @@ class DigitizedWork(ModelIndexable, TrackChangesModel):
         url_opts = {"source_id": self.source_id}
         # start page must be specified if set but must not be included if empty
         if self.pages_orig:
-            url_opts["start_page"] = self.first_page()
+            url_opts["start_page"] = self.first_page
         return reverse("archive:detail", kwargs=url_opts)
 
     def __str__(self):
@@ -676,7 +676,7 @@ class DigitizedWork(ModelIndexable, TrackChangesModel):
 
         # if original page range is set, check that first page is unique
         if self.pages_orig:
-            first_page = self.first_page_original()
+            first_page = self.first_page_original
             # check for other excerpts in this work with the same first page
             other_excerpts = DigitizedWork.objects.filter(
                 source_id=self.source_id
@@ -887,11 +887,13 @@ class DigitizedWork(ModelIndexable, TrackChangesModel):
         },
     }
 
+    @property
     def first_page(self):
         """Number of the first page in range, if this is an excerpt
         (first of original page range, not digital)"""
-        return self.first_page_original()
+        return self.first_page_original
 
+    @property
     def first_page_digital(self):
         """Number of the first page in range (digital pages / page index),
         if this is an excerpt.
@@ -902,6 +904,7 @@ class DigitizedWork(ModelIndexable, TrackChangesModel):
         if self.pages_digital:
             return list(self.page_span)[0]
 
+    @property
     def first_page_original(self):
         """Number of the first page in range (original page numbering)
         if this is an excerpt
@@ -914,11 +917,13 @@ class DigitizedWork(ModelIndexable, TrackChangesModel):
         if match:
             return match.group(1)
 
+    @property
     def last_page(self):
         """Number of the last page in range, if this is an excerpt
         (last of original page range, not digital)"""
-        return self.last_page_original()
+        return self.last_page_original
 
+    @property
     def last_page_digital(self):
         """Number of the last page in range (digital pages / page index),
         if this is an excerpt.
@@ -929,6 +934,7 @@ class DigitizedWork(ModelIndexable, TrackChangesModel):
         if self.pages_digital:
             return list(self.page_span)[-1]
 
+    @property
     def last_page_original(self):
         """Number of the last page in range (original page numbering) if this is an excerpt
 
@@ -942,7 +948,7 @@ class DigitizedWork(ModelIndexable, TrackChangesModel):
 
     def index_id(self):
         """use source id + first page in range (if any) as solr identifier"""
-        first_page = self.first_page()
+        first_page = self.first_page
         if first_page:
             return "%s-p%s" % (self.source_id, first_page)
         return self.source_id
@@ -987,8 +993,8 @@ class DigitizedWork(ModelIndexable, TrackChangesModel):
         return {
             "id": index_id,
             "source_id": self.source_id,
-            "first_page_s": self.first_page(),
-            "last_page_s": self.last_page(),
+            "first_page_s": self.first_page,
+            "last_page_s": self.last_page,
             "group_id_s": index_id,  # for grouping pages by work or excerpt
             "source_t": self.get_source_display(),
             "source_url": self.source_url,
@@ -1011,9 +1017,7 @@ class DigitizedWork(ModelIndexable, TrackChangesModel):
             # hard-coded to distinguish from & sort with pages
             "item_type": "work",
             "order": "0",
-            "work_type_s": self.get_item_type_display()
-            .lower()
-            .replace(" ", "-"),  # full-work, excerpt, or article
+            "work_type_s": self.work_type,
             "book_journal_s": self.book_journal,
         }
 

--- a/ppa/archive/models.py
+++ b/ppa/archive/models.py
@@ -584,6 +584,11 @@ class DigitizedWork(ModelIndexable, TrackChangesModel):
         HathiTrust, Gale, or EEBO-TCP)."""
         return self.source in [self.HATHI, self.GALE, self.EEBO]
 
+    @property
+    def work_type(self):
+        """Work type formatted for COinS metadata (matches Solr field format)."""
+        return self.get_item_type_display().lower().replace(" ", "-")
+
     @cached_property
     def hathi(self):
         """:class:`ppa.archive.hathi.HathiObject` for HathiTrust records,

--- a/ppa/archive/templates/archive/digitizedwork_detail.html
+++ b/ppa/archive/templates/archive/digitizedwork_detail.html
@@ -16,7 +16,7 @@
 <meta name="twitter:data2" content="{{ object.author }}" />
 
 <!-- COinS for Zotero item type recognition and complete metadata -->
-{% if solr_object %}{% coins_data solr_object as coins_metadata %}{{ coins_metadata|coins_encode }}{% endif %}
+{% coins_data object as coins_metadata %}{{ coins_metadata|coins_encode }}
 
 {% endblock %}
 

--- a/ppa/archive/templatetags/ppa_tags.py
+++ b/ppa/archive/templatetags/ppa_tags.py
@@ -129,15 +129,7 @@ def _get_item_value(obj, key, default=None):
         # Try clean field name first (from aliasing)
         value = getattr(obj, key, None)
         if value is not None:
-            # If it's a method (Django model method), call it
-            if callable(value):
-                try:
-                    return value()
-                except TypeError:
-                    # Method requires arguments, skip it
-                    pass
-            else:
-                return value
+            return value
 
         # Fall back to raw Solr field name with _s suffix
         raw_field_name = f"{key}_s"

--- a/ppa/archive/templatetags/ppa_tags.py
+++ b/ppa/archive/templatetags/ppa_tags.py
@@ -129,7 +129,15 @@ def _get_item_value(obj, key, default=None):
         # Try clean field name first (from aliasing)
         value = getattr(obj, key, None)
         if value is not None:
-            return value
+            # If it's a method (Django model method), call it
+            if callable(value):
+                try:
+                    return value()
+                except TypeError:
+                    # Method requires arguments, skip it
+                    pass
+            else:
+                return value
 
         # Fall back to raw Solr field name with _s suffix
         raw_field_name = f"{key}_s"

--- a/ppa/archive/tests/test_gale.py
+++ b/ppa/archive/tests/test_gale.py
@@ -216,14 +216,68 @@ class TestGaleAPI(TestCase):
         assert gale_api.session.get.call_count == 1
 
         # already on a retry (no infinite loops requesting new keys!)
+        # With retry limit of 3, need to use retry=3 to test no more retries
         mock_get_api_key.reset_mock()
         gale_api.session.reset_mock()
         gale_api.session.get.side_effect = [unauth_response, ok_response]
         with pytest.raises(gale.GaleUnauthorized):
-            gale_api._make_request("foo", requires_api_key=True, retry=1)
+            gale_api._make_request("foo", requires_api_key=True, retry=3)
         # should not get a new key; should only make the request once
         mock_get_api_key.assert_not_called()
         assert gale_api.session.get.call_count == 1
+
+    @patch("ppa.archive.gale.GaleAPI.get_api_key")
+    def test_make_request_multiple_retries(self, mock_get_api_key, mockrequests):
+        # test that the new 3-retry logic works correctly
+        gale_api = gale.GaleAPI()
+        gale_api._api_key = None
+        gale_api.api_root = "http://example.com/api"
+        mockrequests.codes = requests.codes
+        mock_get_api_key.side_effect = ("key1", "key2", "key3", "key4")
+
+        # simulate 3 failures followed by success on 4th attempt (3rd retry)
+        unauth_response = Mock(status_code=requests.codes.unauthorized)
+        unauth_response.elapsed.total_seconds.return_value = 1
+        ok_response = Mock(status_code=requests.codes.ok)
+        ok_response.elapsed.total_seconds.return_value = 3
+
+        gale_api.session.get.side_effect = [
+            unauth_response,  # initial request fails
+            unauth_response,  # retry 1 fails
+            unauth_response,  # retry 2 fails
+            ok_response,  # retry 3 succeeds
+        ]
+
+        # should succeed after 3 retries
+        gale_api._make_request("foo", requires_api_key=True)
+
+        # should call get_api_key 4 times: initial + 3 retries
+        assert mock_get_api_key.call_count == 4
+        # should make 4 HTTP requests: initial + 3 retries
+        assert gale_api.session.get.call_count == 4
+
+        # test case where all 3 retries fail
+        mock_get_api_key.reset_mock()
+        gale_api.session.reset_mock()
+        gale_api._api_key = None
+        mock_get_api_key.side_effect = ("key1", "key2", "key3", "key4")
+
+        # all requests fail
+        gale_api.session.get.side_effect = [
+            unauth_response,  # initial request fails
+            unauth_response,  # retry 1 fails
+            unauth_response,  # retry 2 fails
+            unauth_response,  # retry 3 fails
+        ]
+
+        # should raise exception after exhausting all retries
+        with pytest.raises(gale.GaleUnauthorized):
+            gale_api._make_request("foo", requires_api_key=True)
+
+        # should call get_api_key 4 times: initial + 3 retries
+        assert mock_get_api_key.call_count == 4
+        # should make 4 HTTP requests: initial + 3 retries
+        assert gale_api.session.get.call_count == 4
 
     def test_get_api_key(self, mockrequests):
         gale_api = gale.GaleAPI()

--- a/ppa/archive/tests/test_models.py
+++ b/ppa/archive/tests/test_models.py
@@ -837,17 +837,17 @@ class TestDigitizedWork(TestCase):
         assert "start value should exceed stop (355-35)" in str(err)
 
     def test_first_page_digital(self):
-        assert DigitizedWork(pages_digital="133-135").first_page_digital() == 133
+        assert DigitizedWork(pages_digital="133-135").first_page_digital == 133
 
     def test_first_page_original(self):
         # citation-style page range (second number is incomplete)
-        assert DigitizedWork(pages_orig="133-5").first_page_original() == "133"
+        assert DigitizedWork(pages_orig="133-5").first_page_original == "133"
         # single page number
-        assert DigitizedWork(pages_orig="133").first_page_original() == "133"
+        assert DigitizedWork(pages_orig="133").first_page_original == "133"
         # discontinuous page range
-        assert DigitizedWork(pages_orig="133, 134").first_page_original() == "133"
+        assert DigitizedWork(pages_orig="133, 134").first_page_original == "133"
         # roman numreals
-        assert DigitizedWork(pages_orig="iii-xiv").first_page_original() == "iii"
+        assert DigitizedWork(pages_orig="iii-xiv").first_page_original == "iii"
 
     def test_is_suppressed(self):
         work = DigitizedWork(source_id="chi.79279237")

--- a/ppa/archive/tests/test_templatetags.py
+++ b/ppa/archive/tests/test_templatetags.py
@@ -405,10 +405,10 @@ def test_coins_data_mixed_field_names():
 
 def test_coins_data_django_model():
     """Test coins_data with Django model objects.
-    This tests the new functionality where the tag can work directly with
-    DigitizedWork model instances by handling model methods and property conversion.
+    This tests the functionality where the tag can work directly with
+    DigitizedWork model instances using properties.
     """
-    # Mock Django model object with methods and properties
+    # Mock Django model object with properties
     mock_model = Mock()
     mock_model.work_type = "excerpt"  # Property we added
     mock_model.title = "Django Model Test"
@@ -417,9 +417,9 @@ def test_coins_data_django_model():
     mock_model.pub_place = "Model City"
     mock_model.source_id = "django123"
 
-    # Mock methods that need to be called
-    mock_model.first_page = Mock(return_value="5")
-    mock_model.last_page = Mock(return_value="10")
+    # Mock properties
+    mock_model.first_page = "5"
+    mock_model.last_page = "10"
 
     mock_request = Mock()
     mock_request.build_absolute_uri.return_value = (
@@ -438,11 +438,6 @@ def test_coins_data_django_model():
     assert result["btitle"] == "Test Book Journal"  # Containing book title
     assert result["au"] == "Model Author"
     assert result["place"] == "Model City"
-    assert result["spage"] == "5"  # From first_page() method
-    assert result["epage"] == "10"  # From last_page() method
+    assert result["spage"] == "5"  # From first_page property
+    assert result["epage"] == "10"  # From last_page property
     assert result["pages"] == "5-10"  # Constructed range
-
-    # Verify methods were called
-    # first_page is called twice: once for URL generation, once for page metadata
-    assert mock_model.first_page.call_count == 2
-    mock_model.last_page.assert_called_once()

--- a/ppa/archive/tests/test_templatetags.py
+++ b/ppa/archive/tests/test_templatetags.py
@@ -133,14 +133,14 @@ def test_coins_data_full_work():
     # Verify COinS standard compliance
     assert result["ctx_ver"] == "Z39.88-2004"  # COinS version
     assert result["rft_val_fmt"] == "info:ofi/fmt:kev:mtx:book"  # Book format
-    assert result["rft.genre"] == "book"  # Full work type
+    assert result["genre"] == "book"  # Full work type
 
     # Verify bibliographic metadata mapping
-    assert result["rft.title"] == "Test Book"
-    assert result["rft.au"] == "Test Author"
-    assert result["rft.date"] == "1850"
-    assert result["rft.pub"] == "Test Publisher"
-    assert result["rft.place"] == "Cambridge"
+    assert result["title"] == "Test Book"
+    assert result["au"] == "Test Author"
+    assert result["date"] == "1850"
+    assert result["pub"] == "Test Publisher"
+    assert result["place"] == "Cambridge"
     assert result["rft_id"] == "http://testserver/archive/detail/test123/"
 
 
@@ -173,18 +173,18 @@ def test_coins_data_excerpt():
 
     # Verify excerpt-specific COinS formatting
     assert result["rft_val_fmt"] == "info:ofi/fmt:kev:mtx:book"
-    assert result["rft.genre"] == "bookitem"  # Excerpt type
+    assert result["genre"] == "bookitem"  # Excerpt type
 
     # Verify title mapping for excerpts
-    assert result["rft.atitle"] == "Test Excerpt"  # Article/excerpt title
-    assert result["rft.btitle"] == "Test Book"  # Containing book title
+    assert result["atitle"] == "Test Excerpt"  # Article/excerpt title
+    assert result["btitle"] == "Test Book"  # Containing book title
 
     # Verify page range information
-    assert result["rft.au"] == "Test Author"
-    assert result["rft.place"] == "Oxford"
-    assert result["rft.pages"] == "10-15"  # Full page range
-    assert result["rft.spage"] == "10"  # Start page
-    assert result["rft.epage"] == "15"  # End page
+    assert result["au"] == "Test Author"
+    assert result["place"] == "Oxford"
+    assert result["pages"] == "10-15"  # Full page range
+    assert result["spage"] == "10"  # Start page
+    assert result["epage"] == "15"  # End page
 
 
 def test_coins_data_article():
@@ -215,18 +215,18 @@ def test_coins_data_article():
 
     # Verify journal article COinS formatting
     assert result["rft_val_fmt"] == "info:ofi/fmt:kev:mtx:journal"  # Journal format
-    assert result["rft.genre"] == "article"  # Article type
+    assert result["genre"] == "article"  # Article type
 
     # Verify journal-specific metadata mapping
-    assert result["rft.atitle"] == "Test Article"  # Article title
-    assert result["rft.jtitle"] == "Test Journal"  # Journal title
-    assert result["rft.au"] == "Test Author"
-    assert result["rft.volume"] == "Vol. 5"  # Volume/issue info
+    assert result["atitle"] == "Test Article"  # Article title
+    assert result["jtitle"] == "Test Journal"  # Journal title
+    assert result["au"] == "Test Author"
+    assert result["volume"] == "Vol. 5"  # Volume/issue info
 
     # Verify page range for articles
-    assert result["rft.pages"] == "25-30"
-    assert result["rft.spage"] == "25"
-    assert result["rft.epage"] == "30"
+    assert result["pages"] == "25-30"
+    assert result["spage"] == "25"
+    assert result["epage"] == "30"
 
 
 def test_coins_data_solr_object_excerpt():
@@ -258,9 +258,9 @@ def test_coins_data_solr_object_excerpt():
 
     # Verify basic excerpt functionality with Solr objects
     assert result["rft_val_fmt"] == "info:ofi/fmt:kev:mtx:book"
-    assert result["rft.genre"] == "bookitem"
-    assert result["rft.atitle"] == "Test Excerpt"
-    assert result["rft.btitle"] == "Test Book"
+    assert result["genre"] == "bookitem"
+    assert result["atitle"] == "Test Excerpt"
+    assert result["btitle"] == "Test Book"
 
 
 def test_coins_data_dictionary():
@@ -293,9 +293,9 @@ def test_coins_data_dictionary():
 
     # Verify dictionary input produces correct article metadata
     assert result["rft_val_fmt"] == "info:ofi/fmt:kev:mtx:journal"
-    assert result["rft.genre"] == "article"
-    assert result["rft.atitle"] == "Test Article"
-    assert result["rft.jtitle"] == "Test Journal"
+    assert result["genre"] == "article"
+    assert result["atitle"] == "Test Article"
+    assert result["jtitle"] == "Test Journal"
 
 
 def test_coins_encode():
@@ -305,7 +305,7 @@ def test_coins_encode():
         "rft_val_fmt": "info:ofi/fmt:kev:mtx:book",
         "rft.genre": "book",
         "rft.title": "Test & Title",  # Contains special character
-        "au": "Test Author",
+        "rft.au": "Test Author",
         "rft_id": "http://example.com/test?param=value",  # Contains URL characters
     }
 
@@ -364,8 +364,8 @@ def test_coins_data_raw_solr_fields():
     # If the code only looks for clean field names, this should fail
     # because work_type would be None, defaulting to "full-work"
     # But we want it to find work_type_s and use "excerpt"
-    assert result["rft.genre"] == "bookitem"  # Should be excerpt behavior
-    assert result["rft.atitle"] == "Test Excerpt"
+    assert result["genre"] == "bookitem"  # Should be excerpt behavior
+    assert result["atitle"] == "Test Excerpt"
 
 
 def test_coins_data_mixed_field_names():
@@ -399,5 +399,50 @@ def test_coins_data_mixed_field_names():
         result = coins_data(context, mock_item)
 
     assert result["rft_val_fmt"] == "info:ofi/fmt:kev:mtx:journal"
-    assert result["rft.genre"] == "article"
-    assert result["rft.atitle"] == "Test Article"
+    assert result["genre"] == "article"
+    assert result["atitle"] == "Test Article"
+
+
+def test_coins_data_django_model():
+    """Test coins_data with Django model objects.
+    This tests the new functionality where the tag can work directly with
+    DigitizedWork model instances by handling model methods and property conversion.
+    """
+    # Mock Django model object with methods and properties
+    mock_model = Mock()
+    mock_model.work_type = "excerpt"  # Property we added
+    mock_model.title = "Django Model Test"
+    mock_model.author = "Model Author"
+    mock_model.book_journal = "Test Book Journal"
+    mock_model.pub_place = "Model City"
+    mock_model.source_id = "django123"
+
+    # Mock methods that need to be called
+    mock_model.first_page = Mock(return_value="5")
+    mock_model.last_page = Mock(return_value="10")
+
+    mock_request = Mock()
+    mock_request.build_absolute_uri.return_value = (
+        "http://testserver/archive/detail/django123/"
+    )
+    context = {"request": mock_request}
+
+    with patch("django.urls.reverse") as mock_reverse:
+        mock_reverse.return_value = "/archive/detail/django123/"
+        result = coins_data(context, mock_model)
+
+    # Verify Django model functionality
+    assert result["rft_val_fmt"] == "info:ofi/fmt:kev:mtx:book"
+    assert result["genre"] == "bookitem"  # Excerpt type
+    assert result["atitle"] == "Django Model Test"  # Article/excerpt title
+    assert result["btitle"] == "Test Book Journal"  # Containing book title
+    assert result["au"] == "Model Author"
+    assert result["place"] == "Model City"
+    assert result["spage"] == "5"  # From first_page() method
+    assert result["epage"] == "10"  # From last_page() method
+    assert result["pages"] == "5-10"  # Constructed range
+
+    # Verify methods were called
+    # first_page is called twice: once for URL generation, once for page metadata
+    assert mock_model.first_page.call_count == 2
+    mock_model.last_page.assert_called_once()

--- a/ppa/archive/tests/test_views.py
+++ b/ppa/archive/tests/test_views.py
@@ -168,7 +168,7 @@ class TestDigitizedWorkDetailView(TestCase):
         self.assertContains(response, excerpt.title)
         self.assertContains(response, excerpt.book_journal)
         self.assertContains(
-            response, hathi_page_url(excerpt.source_id, excerpt.first_page())
+            response, hathi_page_url(excerpt.source_id, excerpt.first_page)
         )
 
     @patch("ppa.archive.models.DigitizedWork.index_items")
@@ -188,7 +188,7 @@ class TestDigitizedWorkDetailView(TestCase):
         response = self.client.get(excerpt.get_absolute_url())
         self.assertContains(
             response,
-            gale_page_url(excerpt.source_url, excerpt.first_page()).replace(
+            gale_page_url(excerpt.source_url, excerpt.first_page).replace(
                 "&", "&amp;"  # without escaping the ampersand, check fails
             ),
         )
@@ -476,7 +476,7 @@ class TestDigitizedWorkDetailView(TestCase):
                 "archive:detail",
                 kwargs={
                     "source_id": excerpt.source_id,
-                    "start_page": excerpt.first_page_digital(),
+                    "start_page": excerpt.first_page_digital,
                 },
             )
         )

--- a/ppa/archive/views.py
+++ b/ppa/archive/views.py
@@ -384,19 +384,6 @@ class DigitizedWorkDetailView(AjaxTemplateMixin, SolrLastModifiedMixin, DetailVi
         if digwork.is_suppressed:
             return context
 
-        # Fetch Solr data for COinS metadata (ignore if Solr unavailable)
-        try:
-            solr_results = list(
-                ArchiveSearchQuerySet().filter(id=digwork.index_id())[:1]
-            )
-            if solr_results:
-                context["solr_object"] = solr_results[0]
-        except (
-            requests.exceptions.ConnectionError,
-            requests.exceptions.RequestException,
-        ):
-            pass
-
         context.update(
             {"page_title": digwork.title, "page_description": digwork.public_notes}
         )


### PR DESCRIPTION
Changes:
- Remove Solr dependency for COinS metadata generation on digitized work detail pages.
- Simplify and enhance `urlencode` logic.
- Update the logger to keep only the status code, URL, and item ID. #754 
- Fix minor formatting issue in CHANGELOG.rst.

Anything else need to be improved?