### PR TITLE
Improve work-level metadata for full-text data export

### DIFF
--- a/ppa/archive/management/commands/generate_textcorpus.py
+++ b/ppa/archive/management/commands/generate_textcorpus.py
@@ -85,6 +85,9 @@ class Command(BaseCommand):
         },
     }
 
+    #: multivalue delimiter for CSV output (only applies to collections)
+    multival_delimiter = ";"
+
     # Argument parsing
     def add_arguments(self, parser):
         """
@@ -212,9 +215,10 @@ class Command(BaseCommand):
 
             # save csv
             with open(self.path_works_csv, "w", newline="") as csvfile:
-                # fieldnames we already know
-                fieldnames = list(self.FIELDLIST["work"].keys())
-                writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+                # fieldnames are set on the class
+                writer = csv.DictWriter(
+                    csvfile, fieldnames=self.FIELDLIST["work"].keys()
+                )
                 writer.writeheader()
                 writer.writerows(data)
 

--- a/ppa/archive/management/commands/generate_textcorpus.py
+++ b/ppa/archive/management/commands/generate_textcorpus.py
@@ -224,6 +224,8 @@ class Command(BaseCommand):
             }
             # override solr index cluster with cluster id name
             work_data["cluster_id"] = str(digwork.cluster) if digwork.cluster else None
+            # override work type with display value instead of slugified version
+            work_data["work_type"] = digwork.get_item_type_display()
             # filter out any empty values
             work_data = {key: val for key, val in work_data.items() if val}
 

--- a/ppa/archive/management/commands/generate_textcorpus.py
+++ b/ppa/archive/management/commands/generate_textcorpus.py
@@ -219,7 +219,8 @@ class Command(BaseCommand):
         ready for output to CSV: converts list field (collections) into
         a delimited string.
         """
-        for record in data:
+        for row in data:
+            record = row.copy()  # make a copy; don't modify the original
             # convert list field to delimited string
             record["collections"] = self.multival_delimiter.join(record["collections"])
             yield record

--- a/ppa/archive/management/commands/generate_textcorpus.py
+++ b/ppa/archive/management/commands/generate_textcorpus.py
@@ -87,11 +87,15 @@ class Command(BaseCommand):
             "source_url": "source_url",
             "sort_title": "sort_title",
             "subtitle": "subtitle",
+            "volume": "enumcron",
+            "book_journal": "book_journal_s",
         },
     }
 
     #: multivalue delimiter for CSV output (only applies to collections)
     multival_delimiter = ";"
+    #: optional behavior to generate metadata export only
+    metadata_only = False
 
     # Argument parsing
     def add_arguments(self, parser):
@@ -271,7 +275,7 @@ class Command(BaseCommand):
         self.path_works_csv = os.path.join(self.path, "ppa_metadata.csv")
         jsonl_ext = "jsonl.gz" if options.get("gzip") else "jsonl"
         self.path_pages_json = os.path.join(self.path, f"ppa_pages.{jsonl_ext}")
-        self.metadata_only = options.get("metadata_only")
+        self.metadata_only = options.get("metadata_only", False)
         self.is_dry_run = options.get("dry_run")
         self.doclimit = options.get("doc_limit")
         self.verbosity = options.get("verbosity", self.verbosity)

--- a/ppa/archive/tests/test_generate_textcorpus.py
+++ b/ppa/archive/tests/test_generate_textcorpus.py
@@ -26,7 +26,7 @@ sample_page_content = [
 
 
 @pytest.fixture()
-def sample_works(db):
+def sample_works(db, empty_solr):
     # load fixture works and index works and pages in Solr
     call_command("loaddata", "sample_digitized_works")
     # index in Solr

--- a/ppa/archive/tests/test_generate_textcorpus.py
+++ b/ppa/archive/tests/test_generate_textcorpus.py
@@ -215,6 +215,8 @@ def test_save_metadata(sample_works, tmp_path):
             assert isinstance(json_data["cluster_id"], str)
         else:
             assert "cluster_id" not in json_data
+        # work type should be display value instead of slugified version
+        assert json_data["work_type"] == digwork.get_item_type_display()
 
         # a few fields vary in CSV and JSON output
         json_pubyear = json_data.pop("pub_year")


### PR DESCRIPTION
**Associated Issue:** resolves #632 

### Changes in this PR

- Revise `generate_textcorpus` manage command for work metadata export
- Refactor unit tests; rely on existing fixture data and test with Solr