### PR TITLE
Upgrade solr from 9.2 to 9.9

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -45,7 +45,9 @@ jobs:
         ports:
           - 5432:5432
       solr:
-        image: solr:9.2
+        image: solr:9.9
+        env:
+          SOLR_MODULES: extraction,clustering,langid,analysis-extras,scripting
         ports:
           - 8983:8983
     steps:

--- a/ppa/dataset/tests/test_generate_textcorpus.py
+++ b/ppa/dataset/tests/test_generate_textcorpus.py
@@ -333,18 +333,6 @@ def test_set_params(options, expected, tmp_path):
         assert attr_value == expected_value
 
 
-def test_default_args(mock_iter_pages, mock_work_metadata):
-    # testing default args requires running with call_commmand
-    cmd = generate_textcorpus.Command()
-    # change working directory to temp path to avoid accumulating empty
-    # export directories in the project working director
-    call_command(cmd)
-    assert cmd.doclimit is None
-    assert cmd.verbosity == cmd.v_normal
-    # compression for page output enabled by  default
-    assert cmd.batch_size == generate_textcorpus.DEFAULT_BATCH_SIZE
-
-
 def test_handle(sample_works, tmp_path, capsys):
     output_dir = tmp_path / "output"
     cmd = generate_textcorpus.Command()

--- a/ppa/dataset/tests/test_generate_textcorpus.py
+++ b/ppa/dataset/tests/test_generate_textcorpus.py
@@ -333,20 +333,15 @@ def test_set_params(options, expected, tmp_path):
         assert attr_value == expected_value
 
 
-@patch("ppa.dataset.management.commands.generate_textcorpus.Command.work_metadata")
-@patch("ppa.dataset.management.commands.generate_textcorpus.Command.iter_pages")
-def test_default_args(mock_iter_pages, mock_work_metadata, tmp_path):
+def test_default_args(mock_iter_pages, mock_work_metadata):
     # testing default args requires running with call_commmand
     cmd = generate_textcorpus.Command()
     # change working directory to temp path to avoid accumulating empty
     # export directories in the project working director
-    os.chdir(tmp_path)
     call_command(cmd)
-    assert cmd.path == pathlib.Path("ppa_corpus_" + generate_textcorpus.nowstr())
     assert cmd.doclimit is None
     assert cmd.verbosity == cmd.v_normal
     # compression for page output enabled by  default
-    assert cmd.path_pages_json.suffix == ".gz"
     assert cmd.batch_size == generate_textcorpus.DEFAULT_BATCH_SIZE
 
 

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -72,13 +72,7 @@
        The example below can be used to load a Solr Module along
        with their external dependencies.
     -->
-  
-  <!-- Scripting module required by XSLTResponseWriter -->     
-  <lib dir="${solr.install.dir:../../../..}/modules/scripting/lib" regex=".*\.jar" />
-  <!-- Required jars for ICU Folding -->
-  <lib dir="${solr.install.dir:../../../..}/modules/analysis-extras/lib/" regex="solr-analysis-extras-\d.*\.jar" />
-  <lib dir="${solr.install.dir:../../../..}/modules/analysis-extras/lib/" regex="lucene-analysis-icu-\d.*\.jar" />
-  <lib dir="${solr.install.dir:../../../..}/modules/analysis-extras/lib/" regex="icu4j-\d.*\.jar" />
+
   
   <!-- an exact 'path' can be used instead of a 'dir' to specify a
        specific jar file.  This will cause a serious error to be logged


### PR DESCRIPTION
### Changes in this PR

- Upgrading solr config in the repo CI (GitHub action unit-tests.yml) from 9.2 to 9.9
- Removing the [deprecated use of lib directives](https://solr.apache.org/guide/solr/latest/configuration-guide/libs.html#:~:text=%3Clib/%3E,sysprop%20to%20true.) from the repo's solr config file solrconf/conf/solrconfig.xml
- Importing the needed solr modules in GitHub action unit-tests.yml by another way that is supported and encouraged by solr starting 9.9 onwards



### Reviewer Checklist

- [x] All JavaScript tests pass
- [x] All Python tests pass
- [x] All 12 automated checks pass
- [ ] The application (including the search function) works as expected locally and in staging
